### PR TITLE
Exceptions diagnostics

### DIFF
--- a/src/core/Hocon/Hocon.csproj
+++ b/src/core/Hocon/Hocon.csproj
@@ -55,11 +55,13 @@
     <Compile Include="Hocon\HoconConfigurationElement.cs" />
     <Compile Include="Hocon\HoconLiteral.cs" />
     <Compile Include="Hocon\HoconObject.cs" />
+    <Compile Include="Hocon\HoconParserException.cs" />
     <Compile Include="Hocon\HoconParser.cs" />
     <Compile Include="Hocon\HoconRoot.cs" />
     <Compile Include="Hocon\HoconSubstitution.cs" />
     <Compile Include="Hocon\HoconToken.cs" />
     <Compile Include="Hocon\HoconTokenizer.cs" />
+    <Compile Include="Hocon\HoconTokenizerException.cs" />
     <Compile Include="Hocon\HoconValue.cs" />
     <Compile Include="Hocon\IHoconElement.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/core/Hocon/Hocon/HoconParser.cs
+++ b/src/core/Hocon/Hocon/HoconParser.cs
@@ -68,7 +68,7 @@ namespace Configuration.Hocon
             {
                 HoconValue res = c.GetValue(sub.Path);
                 if (res == null)
-                    throw new FormatException("Unresolved substitution:" + sub.Path);
+                    throw new HoconParserException("Unresolved substitution:" + sub.Path);
 
                 sub.ResolvedValue = res;
             }
@@ -234,7 +234,7 @@ namespace Configuration.Hocon
                 //no value was found, tokenizer is still at the same position
                 if (_reader.Index == start)
                 {
-                    throw new FormatException(string.Format("Hocon syntax error {0}\r{1}",_reader.GetHelpTextAtIndex(start),GetDiagnosticsStackTrace()));
+                    throw new HoconParserException(string.Format("Hocon syntax error {0}\r{1}",_reader.GetHelpTextAtIndex(start),GetDiagnosticsStackTrace()));
                 }
             }
         }

--- a/src/core/Hocon/Hocon/HoconParser.cs
+++ b/src/core/Hocon/Hocon/HoconParser.cs
@@ -21,6 +21,23 @@ namespace Configuration.Hocon
         private HoconTokenizer _reader;
         private HoconValue _root;
         private Func<string, HoconRoot> _includeCallback;
+        private Stack<string> _diagnosticsStack = new Stack<string>();
+
+        private void PushDiagnostics(string message)
+        {
+            _diagnosticsStack.Push(message);
+        }
+
+        private void PopDiagnostics()
+        {
+            _diagnosticsStack.Pop();
+        }
+
+        public string GetDiagnosticsStackTrace()
+        {
+            var currentPath = string.Join("", _diagnosticsStack.Reverse());
+            return string.Format("Current path: {0}", currentPath);
+        }
 
         /// <summary>
         /// Parses the supplied HOCON configuration string into a root element.
@@ -52,6 +69,7 @@ namespace Configuration.Hocon
                 HoconValue res = c.GetValue(sub.Path);
                 if (res == null)
                     throw new FormatException("Unresolved substitution:" + sub.Path);
+
                 sub.ResolvedValue = res;
             }
             return new HoconRoot(_root, _substitutions);
@@ -59,76 +77,94 @@ namespace Configuration.Hocon
 
         private void ParseObject(HoconValue owner, bool root,string currentPath)
         {
-            if (owner.IsObject())
+            try
             {
-                //the value of this KVP is already an object
-            }
-            else
-            {
-                //the value of this KVP is not an object, thus, we should add a new
-                owner.NewValue(new HoconObject());
-            }
+                PushDiagnostics("{");
 
-            HoconObject currentObject = owner.GetObject();
-
-            while (!_reader.EoF)
-            {
-                Token t = _reader.PullNext();
-                switch (t.Type)
+                if (owner.IsObject())
                 {
-                    case TokenType.Include:
-                        var included = _includeCallback(t.Value);
-                        var substitutions = included.Substitutions;
-                        foreach (var substitution in substitutions)
-                        {
-                            //fixup the substitution, add the current path as a prefix to the substitution path
-                            substitution.Path = currentPath + "." + substitution.Path;
-                        }
-                        _substitutions.AddRange(substitutions);
-                        var otherObj = included.Value.GetObject();
-                        owner.GetObject().Merge(otherObj);
-
-                        break;
-                    case TokenType.EoF:
-                        break;
-                    case TokenType.Key:
-                        HoconValue value = currentObject.GetOrCreateKey(t.Value);
-                        var nextPath = currentPath == "" ? t.Value : currentPath + "." + t.Value;
-                        ParseKeyContent(value, nextPath);
-                        if (!root)
-                            return;
-                        break;
-
-                    case TokenType.ObjectEnd:
-                        return;
+                    //the value of this KVP is already an object
                 }
+                else
+                {
+                    //the value of this KVP is not an object, thus, we should add a new
+                    owner.NewValue(new HoconObject());
+                }
+
+                HoconObject currentObject = owner.GetObject();
+
+                while (!_reader.EoF)
+                {
+                    Token t = _reader.PullNext();
+                    switch (t.Type)
+                    {
+                        case TokenType.Include:
+                            var included = _includeCallback(t.Value);
+                            var substitutions = included.Substitutions;
+                            foreach (var substitution in substitutions)
+                            {
+                                //fixup the substitution, add the current path as a prefix to the substitution path
+                                substitution.Path = currentPath + "." + substitution.Path;
+                            }
+                            _substitutions.AddRange(substitutions);
+                            var otherObj = included.Value.GetObject();
+                            owner.GetObject().Merge(otherObj);
+
+                            break;
+                        case TokenType.EoF:
+                            break;
+                        case TokenType.Key:
+                            HoconValue value = currentObject.GetOrCreateKey(t.Value);
+                            var nextPath = currentPath == "" ? t.Value : currentPath + "." + t.Value;
+                            ParseKeyContent(value, nextPath);
+                            if (!root)
+                                return;
+                            break;
+
+                        case TokenType.ObjectEnd:
+                            return;
+                    }
+                }
+            }
+            finally
+            {
+                PopDiagnostics();
             }
         }
 
         private void ParseKeyContent(HoconValue value,string currentPath)
         {
-            while (!_reader.EoF)
+            try
             {
-                Token t = _reader.PullNext();
-                switch (t.Type)
+                var last = currentPath.Split('.').Last();
+                PushDiagnostics(string.Format("{0} = ", last));
+                while (!_reader.EoF)
                 {
-                    case TokenType.Dot:
-                        ParseObject(value, false,currentPath);
-                        return;
-                    case TokenType.Assign:
-                        
-                        if (!value.IsObject())
-                        {
-                            //if not an object, then replace the value.
-                            //if object. value should be merged
-                            value.Clear();
-                        }
-                        ParseValue(value,currentPath);
-                        return;
-                    case TokenType.ObjectStart:
-                        ParseObject(value, true,currentPath);
-                        return;
+                    Token t = _reader.PullNext();
+                    switch (t.Type)
+                    {
+                        case TokenType.Dot:
+                            ParseObject(value, false, currentPath);
+                            return;
+                        case TokenType.Assign:
+
+                            if (!value.IsObject())
+                            {
+                                //if not an object, then replace the value.
+                                //if object. value should be merged
+                                value.Clear();
+                            }
+                            ParseValue(value, currentPath);
+                            return;
+                        case TokenType.ObjectStart:
+                            ParseObject(value, true, currentPath);
+                            return;
+                    }
                 }
+            }
+            finally
+            {
+                PopDiagnostics();
             }
         }
 
@@ -141,50 +177,66 @@ namespace Configuration.Hocon
         public void ParseValue(HoconValue owner,string currentPath)
         {
             if (_reader.EoF)
-                throw new Exception("End of file reached while trying to read a value");
+                throw new HoconParserException("End of file reached while trying to read a value");
 
             _reader.PullWhitespaceAndComments();
-            while (_reader.IsValue())
+            var start = _reader.Index;
+            try
             {
-                Token t = _reader.PullValue();
-
-                switch (t.Type)
+                while (_reader.IsValue())
                 {
-                    case TokenType.EoF:
-                        break;
-                    case TokenType.LiteralValue:
-                        if (owner.IsObject())
-                        {
-                            //needed to allow for override objects
-                            owner.Clear();
-                        }
-                        var lit = new HoconLiteral
-                        {
-                            Value = t.Value
-                        };
-                        owner.AppendValue(lit);
+                    Token t = _reader.PullValue();
 
-                        break;
-                    case TokenType.ObjectStart:
-                        ParseObject(owner, true,currentPath);
-                        break;
-                    case TokenType.ArrayStart:
-                        HoconArray arr = ParseArray(currentPath);
-                        owner.AppendValue(arr);
-                        break;
-                    case TokenType.Substitute:
-                        HoconSubstitution sub = ParseSubstitution(t.Value);
-                        _substitutions.Add(sub);
-                        owner.AppendValue(sub);
-                        break;
+                    switch (t.Type)
+                    {
+                        case TokenType.EoF:
+                            break;
+                        case TokenType.LiteralValue:
+                            if (owner.IsObject())
+                            {
+                                //needed to allow for override objects
+                                owner.Clear();
+                            }
+                            var lit = new HoconLiteral
+                            {
+                                Value = t.Value
+                            };
+                            owner.AppendValue(lit);
+
+                            break;
+                        case TokenType.ObjectStart:
+                            ParseObject(owner, true, currentPath);
+                            break;
+                        case TokenType.ArrayStart:
+                            HoconArray arr = ParseArray(currentPath);
+                            owner.AppendValue(arr);
+                            break;
+                        case TokenType.Substitute:
+                            HoconSubstitution sub = ParseSubstitution(t.Value);
+                            _substitutions.Add(sub);
+                            owner.AppendValue(sub);
+                            break;
+                    }
+                    if (_reader.IsSpaceOrTab())
+                    {
+                        ParseTrailingWhitespace(owner);
+                    }
                 }
-                if (_reader.IsSpaceOrTab())
+
+                IgnoreComma();
+            }
+            catch(HoconTokenizerException tokenizerException)
+            {
+                throw new HoconParserException(string.Format("{0}\r{1}", tokenizerException.Message, GetDiagnosticsStackTrace()),tokenizerException);
+            }
+            finally
+            {
+                //no value was found, tokenizer is still at the same position
+                if (_reader.Index == start)
                 {
-                    ParseTrailingWhitespace(owner);
+                    throw new FormatException(string.Format("Hocon syntax error {0}\r{1}",_reader.GetHelpTextAtIndex(start),GetDiagnosticsStackTrace()));
                 }
             }
-
-            IgnoreComma();
         }
 
         private void ParseTrailingWhitespace(HoconValue owner)
@@ -212,16 +264,25 @@ namespace Configuration.Hocon
         /// <returns>An array of elements retrieved from the token.</returns>
         public HoconArray ParseArray(string currentPath)
         {
-            var arr = new HoconArray();
-            while (!_reader.EoF && !_reader.IsArrayEnd())
+            try
             {
-                var v = new HoconValue();
-                ParseValue(v,currentPath);
-                arr.Add(v);
-                _reader.PullWhitespaceAndComments();
+                PushDiagnostics("[");
+
+                var arr = new HoconArray();
+                while (!_reader.EoF && !_reader.IsArrayEnd())
+                {
+                    var v = new HoconValue();
+                    ParseValue(v, currentPath);
+                    arr.Add(v);
+                    _reader.PullWhitespaceAndComments();
+                }
+                _reader.PullArrayEnd();
+                return arr;
             }
-            _reader.PullArrayEnd();
-            return arr;
+            finally
+            {
+                PopDiagnostics();
+            }
         }
 
         private void IgnoreComma()

--- a/src/core/Hocon/Hocon/HoconParserException.cs
+++ b/src/core/Hocon/Hocon/HoconParserException.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Configuration.Hocon
+{
+    public class HoconParserException : Exception
+    {
+        public HoconParserException(string message) : base(message)
+        {
+        }
+
+        public HoconParserException(string message,Exception innerException) : base(message,innerException)
+        {
+        }
+    }
+}

--- a/src/core/Hocon/Hocon/HoconToken.cs
+++ b/src/core/Hocon/Hocon/HoconToken.cs
@@ -81,18 +81,26 @@ namespace Configuration.Hocon
     /// </summary>
     public class Token
     {
+        public int SourceIndex { get; private set; }
+        public int Length { get;private set; }
         /// <summary>
         /// Initializes a new instance of the <see cref="Token"/> class.
         /// </summary>
-        protected Token()
+        protected Token(int sourceIndex, int sourceLength)
         {
+        }
+
+        public Token(string value, TokenType type, int sourceIndex, int sourceLength) : this(sourceIndex, sourceLength)
+        {
+            Type = type;
+            Value = value;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Token"/> class.
         /// </summary>
         /// <param name="type">The type of token to associate with.</param>
-        public Token(TokenType type)
+        public Token(TokenType type, int sourceIndex, int sourceLength) : this(sourceIndex,sourceLength)
         {
             Type = type;
         }
@@ -101,7 +109,7 @@ namespace Configuration.Hocon
         /// Initializes a new instance of the <see cref="Token"/> class.
         /// </summary>
         /// <param name="value">The string literal value to associate with this token.</param>
-        public Token(string value)
+        public Token(string value, int sourceIndex, int sourceLength) : this(sourceIndex, sourceLength)
         {
             Type = TokenType.LiteralValue;
             Value = value;
@@ -124,13 +132,9 @@ namespace Configuration.Hocon
         /// </summary>
         /// <param name="key">The key to associate with this token.</param>
         /// <returns>A key token with the given key.</returns>
-        public static Token Key(string key)
+        public static Token Key(string key, int sourceIndex, int sourceLength)
         {
-            return new Token
-            {
-                Type = TokenType.Key,
-                Value = key,
-            };
+            return new Token(key,TokenType.Key, sourceIndex, sourceLength);
         }
 
         /// <summary>
@@ -138,13 +142,9 @@ namespace Configuration.Hocon
         /// </summary>
         /// <param name="path">The path to associate with this token.</param>
         /// <returns>A substitution token with the given path.</returns>
-        public static Token Substitution(string path)
+        public static Token Substitution(string path, int sourceIndex, int sourceLength)
         {
-            return new Token
-            {
-                Type = TokenType.Substitute,
-                Value = path,
-            };
+            return new Token(path, TokenType.Substitute, sourceIndex, sourceLength);
         }
 
         /// <summary>
@@ -152,22 +152,14 @@ namespace Configuration.Hocon
         /// </summary>
         /// <param name="value">The value to associate with this token.</param>
         /// <returns>A string literal token with the given value.</returns>
-        public static Token LiteralValue(string value)
+        public static Token LiteralValue(string value, int sourceIndex, int sourceLength)
         {
-            return new Token
-            {
-                Type = TokenType.LiteralValue,
-                Value = value,
-            };
+            return new Token(value, TokenType.LiteralValue, sourceIndex, sourceLength);
         }
 
-        internal static Token Include(string path)
+        internal static Token Include(string path, int sourceIndex, int sourceLength)
         {
-            return new Token
-            {
-                Value = path,
-                Type = TokenType.Include
-            };
+            return new Token(path, TokenType.Include, sourceIndex, sourceLength);
         }
     }
 }

--- a/src/core/Hocon/Hocon/HoconToken.cs
+++ b/src/core/Hocon/Hocon/HoconToken.cs
@@ -83,36 +83,35 @@ namespace Configuration.Hocon
     {
         public int SourceIndex { get; private set; }
         public int Length { get;private set; }
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Token"/> class.
-        /// </summary>
-        protected Token(int sourceIndex, int sourceLength)
+
+        //for serialization
+        private Token()
         {
         }
 
-        public Token(string value, TokenType type, int sourceIndex, int sourceLength) : this(sourceIndex, sourceLength)
+
+        public Token(string value, TokenType type, int sourceIndex, int sourceLength)
         {
             Type = type;
             Value = value;
+            SourceIndex = sourceIndex;
+            Length = sourceLength;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Token"/> class.
         /// </summary>
         /// <param name="type">The type of token to associate with.</param>
-        public Token(TokenType type, int sourceIndex, int sourceLength) : this(sourceIndex,sourceLength)
+        public Token(TokenType type, int sourceIndex, int sourceLength) : this(null,type, sourceIndex,sourceLength)
         {
-            Type = type;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Token"/> class.
         /// </summary>
         /// <param name="value">The string literal value to associate with this token.</param>
-        public Token(string value, int sourceIndex, int sourceLength) : this(sourceIndex, sourceLength)
+        public Token(string value, int sourceIndex, int sourceLength) : this(value, TokenType.LiteralValue, sourceIndex, sourceLength)
         {
-            Type = TokenType.LiteralValue;
-            Value = value;
         }
 
         /// <summary>
@@ -120,12 +119,12 @@ namespace Configuration.Hocon
         /// a <see cref="TokenType.LiteralValue"/>, then this property
         /// holds the string literal.
         /// </summary>
-        public string Value { get; set; }
+        public string Value { get; private set; }
 
         /// <summary>
         /// The type that represents this token.
         /// </summary>
-        public TokenType Type { get; set; }
+        public TokenType Type { get; private set; }
 
         /// <summary>
         /// Creates a key token with a given <paramref name="key"/>.
@@ -157,7 +156,7 @@ namespace Configuration.Hocon
             return new Token(value, TokenType.LiteralValue, sourceIndex, sourceLength);
         }
 
-        internal static Token Include(string path, int sourceIndex, int sourceLength)
+        public static Token Include(string path, int sourceIndex, int sourceLength)
         {
             return new Token(path, TokenType.Include, sourceIndex, sourceLength);
         }

--- a/src/core/Hocon/Hocon/HoconTokenizerException.cs
+++ b/src/core/Hocon/Hocon/HoconTokenizerException.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Configuration.Hocon
+{
+    public class HoconTokenizerException : Exception
+    {
+        public HoconTokenizerException(string message) : base(message)
+        {
+        }
+    }
+}


### PR DESCRIPTION
This PR adds significantly better exception information when a parser problem occurs.
Instead of just throwing and reporting that something broke, we now report where the source text and where in the HOCON tree the problem occured, 

![hoconparseexception](https://cloud.githubusercontent.com/assets/647031/9137154/1c11676c-3d1c-11e5-91d0-92ca7eff2140.png)

In the screenshot this hocon was used:
```javascript
root {
   some-property1 = [ 
   some-property2 = 234     ///"some-property" was added to the array as an unquoted string and "= 234" was considered an unknown token.
}
```

cc @nvivo you wanted better error reporting on hocon, any feedback on how to improve this even more would be great

Related to #13