### PR TITLE
- Change Assembly Name to Akka

### DIFF
--- a/src/Hocon.sln
+++ b/src/Hocon.sln
@@ -1,9 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hocon", "core\Hocon\Hocon.csproj", "{4A87AD05-BEF2-4B08-BD7E-A9866D88C439}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka", "core\Hocon\Akka.csproj", "{4A87AD05-BEF2-4B08-BD7E-A9866D88C439}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hocon.Tests", "core\Hocon.Tests\Hocon.Tests.csproj", "{4FFD147E-6F27-45AA-B2ED-AD2DA599C532}"
 EndProject

--- a/src/Hocon.sln
+++ b/src/Hocon.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka", "core\Hocon\Akka.csproj", "{4A87AD05-BEF2-4B08-BD7E-A9866D88C439}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Hocon", "core\Hocon\Akka.Hocon.csproj", "{4A87AD05-BEF2-4B08-BD7E-A9866D88C439}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hocon.Tests", "core\Hocon.Tests\Hocon.Tests.csproj", "{4FFD147E-6F27-45AA-B2ED-AD2DA599C532}"
 EndProject

--- a/src/core/Hocon/Akka.Hocon.csproj
+++ b/src/core/Hocon/Akka.Hocon.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Akka.Configuration</RootNamespace>
-    <AssemblyName>Akka</AssemblyName>
+    <AssemblyName>Akka.Hocon</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />

--- a/src/core/Hocon/Akka.csproj
+++ b/src/core/Hocon/Akka.csproj
@@ -7,8 +7,8 @@
     <ProjectGuid>{4A87AD05-BEF2-4B08-BD7E-A9866D88C439}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Hocon</RootNamespace>
-    <AssemblyName>Hocon</AssemblyName>
+    <RootNamespace>Akka.Configuration</RootNamespace>
+    <AssemblyName>Akka</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
@@ -49,21 +49,21 @@
     <Compile Include="Configuration\Config.cs" />
     <Compile Include="Configuration\ConfigurationException.cs" />
     <Compile Include="Configuration\ConfigurationFactory.cs" />
-    <Compile Include="Hocon\AkkaConfigurationSection.cs" />
-    <Compile Include="Hocon\CDataConfigurationElement.cs" />
-    <Compile Include="Hocon\HoconArray.cs" />
-    <Compile Include="Hocon\HoconConfigurationElement.cs" />
-    <Compile Include="Hocon\HoconLiteral.cs" />
-    <Compile Include="Hocon\HoconObject.cs" />
-    <Compile Include="Hocon\HoconParserException.cs" />
-    <Compile Include="Hocon\HoconParser.cs" />
-    <Compile Include="Hocon\HoconRoot.cs" />
-    <Compile Include="Hocon\HoconSubstitution.cs" />
-    <Compile Include="Hocon\HoconToken.cs" />
-    <Compile Include="Hocon\HoconTokenizer.cs" />
-    <Compile Include="Hocon\HoconTokenizerException.cs" />
-    <Compile Include="Hocon\HoconValue.cs" />
-    <Compile Include="Hocon\IHoconElement.cs" />
+    <Compile Include="Configuration\Hocon\AkkaConfigurationSection.cs" />
+    <Compile Include="Configuration\Hocon\CDataConfigurationElement.cs" />
+    <Compile Include="Configuration\Hocon\HoconArray.cs" />
+    <Compile Include="Configuration\Hocon\HoconConfigurationElement.cs" />
+    <Compile Include="Configuration\Hocon\HoconLiteral.cs" />
+    <Compile Include="Configuration\Hocon\HoconObject.cs" />
+    <Compile Include="Configuration\Hocon\HoconParserException.cs" />
+    <Compile Include="Configuration\Hocon\HoconParser.cs" />
+    <Compile Include="Configuration\Hocon\HoconRoot.cs" />
+    <Compile Include="Configuration\Hocon\HoconSubstitution.cs" />
+    <Compile Include="Configuration\Hocon\HoconToken.cs" />
+    <Compile Include="Configuration\Hocon\HoconTokenizer.cs" />
+    <Compile Include="Configuration\Hocon\HoconTokenizerException.cs" />
+    <Compile Include="Configuration\Hocon\HoconValue.cs" />
+    <Compile Include="Configuration\Hocon\IHoconElement.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/core/Hocon/Configuration/Config.cs
+++ b/src/core/Hocon/Configuration/Config.cs
@@ -5,11 +5,11 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using Akka.Configuration.Hocon;
 using System;
 using System.Collections.Generic;
-using Configuration.Hocon;
 
-namespace Configuration
+namespace Akka.Configuration
 {
     /// <summary>
     /// This class represents the main configuration object used by a project

--- a/src/core/Hocon/Configuration/ConfigurationException.cs
+++ b/src/core/Hocon/Configuration/ConfigurationException.cs
@@ -8,7 +8,7 @@
 using System;
 using System.Runtime.Serialization;
 
-namespace Configuration
+namespace Akka.Configuration
 {
     /// <summary>
     /// The exception that is thrown when a configuration is invalid.

--- a/src/core/Hocon/Configuration/ConfigurationFactory.cs
+++ b/src/core/Hocon/Configuration/ConfigurationFactory.cs
@@ -10,10 +10,10 @@ using System.Configuration;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
-using Configuration.Hocon;
 using Newtonsoft.Json;
+using Akka.Configuration.Hocon;
 
-namespace Configuration
+namespace Akka.Configuration
 {
     /// <summary>
     /// This class contains methods used to retrieve configuration information

--- a/src/core/Hocon/Configuration/Hocon/AkkaConfigurationSection.cs
+++ b/src/core/Hocon/Configuration/Hocon/AkkaConfigurationSection.cs
@@ -7,7 +7,7 @@
 
 using System.Configuration;
 
-namespace Configuration.Hocon
+namespace Akka.Configuration.Hocon
 {
     /// <summary>
     /// This class represents a custom akka node within a configuration file.
@@ -16,7 +16,7 @@ namespace Configuration.Hocon
     /// <?xml version="1.0" encoding="utf-8" ?>
     /// <configuration>
     ///   <configSections>
-    ///     <section name="akka" type="Configuration.Hocon.AkkaConfigurationSection, Akka" />
+    ///     <section name="akka" type="Akka.Configuration.Hocon.AkkaConfigurationSection, Akka" />
     ///   </configSections>
     ///   <akka>
     ///   ...
@@ -46,7 +46,7 @@ namespace Configuration.Hocon
         /// <?xml version="1.0" encoding="utf-8" ?>
         /// <configuration>
         ///   <configSections>
-        ///     <section name="akka" type="Configuration.Hocon.AkkaConfigurationSection, Akka" />
+        ///     <section name="akka" type="AkkaConfiguration.Hocon.AkkaConfigurationSection, Akka" />
         ///   </configSections>
         ///   <akka>
         ///      <hocon>

--- a/src/core/Hocon/Configuration/Hocon/CDataConfigurationElement.cs
+++ b/src/core/Hocon/Configuration/Hocon/CDataConfigurationElement.cs
@@ -8,7 +8,7 @@
 using System.Configuration;
 using System.Xml;
 
-namespace Configuration.Hocon
+namespace Akka.Configuration.Hocon
 {
     /// <summary>
     /// This class represents the base implementation for retrieving text from
@@ -18,7 +18,7 @@ namespace Configuration.Hocon
     /// <?xml version="1.0" encoding="utf-8" ?>
     /// <configuration>
     ///   <configSections>
-    ///     <section name="akka" type="Configuration.Hocon.AkkaConfigurationSection, Akka" />
+    ///     <section name="akka" type="Akka.Configuration.Hocon.AkkaConfigurationSection, Akka" />
     ///   </configSections>
     ///   <akka>
     ///     <hocon>

--- a/src/core/Hocon/Configuration/Hocon/HoconArray.cs
+++ b/src/core/Hocon/Configuration/Hocon/HoconArray.cs
@@ -8,7 +8,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Configuration.Hocon
+namespace Akka.Configuration.Hocon
 {
     /// <summary>
     /// This class represents an array element in a HOCON (Human-Optimized Config Object Notation)

--- a/src/core/Hocon/Configuration/Hocon/HoconConfigurationElement.cs
+++ b/src/core/Hocon/Configuration/Hocon/HoconConfigurationElement.cs
@@ -7,7 +7,7 @@
 
 using System.Configuration;
 
-namespace Configuration.Hocon
+namespace Akka.Configuration.Hocon
 {
     /// <summary>
     /// This class represents a custom HOCON (Human-Optimized Config Object Notation)
@@ -17,7 +17,7 @@ namespace Configuration.Hocon
     /// <?xml version="1.0" encoding="utf-8" ?>
     /// <configuration>
     ///   <configSections>
-    ///     <section name="akka" type="Configuration.Hocon.AkkaConfigurationSection, Akka" />
+    ///     <section name="akka" type="AkkaConfiguration.Hocon.AkkaConfigurationSection, Akka" />
     ///   </configSections>
     ///   <akka>
     ///     <hocon>

--- a/src/core/Hocon/Configuration/Hocon/HoconLiteral.cs
+++ b/src/core/Hocon/Configuration/Hocon/HoconLiteral.cs
@@ -8,7 +8,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Configuration.Hocon
+namespace Akka.Configuration.Hocon
 {
     /// <summary>
     /// This class represents a string literal element in a HOCON (Human-Optimized Config Object Notation)

--- a/src/core/Hocon/Configuration/Hocon/HoconObject.cs
+++ b/src/core/Hocon/Configuration/Hocon/HoconObject.cs
@@ -11,7 +11,7 @@ using System.Linq;
 using System.Text;
 using Newtonsoft.Json;
 
-namespace Configuration.Hocon
+namespace Akka.Configuration.Hocon
 {
     /// <summary>
     /// This class represents an object element in a HOCON (Human-Optimized Config Object Notation)

--- a/src/core/Hocon/Configuration/Hocon/HoconParser.cs
+++ b/src/core/Hocon/Configuration/Hocon/HoconParser.cs
@@ -9,7 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Configuration.Hocon
+namespace Akka.Configuration.Hocon
 {
     /// <summary>
     /// This class contains methods used to parse HOCON (Human-Optimized Config Object Notation)

--- a/src/core/Hocon/Configuration/Hocon/HoconParserException.cs
+++ b/src/core/Hocon/Configuration/Hocon/HoconParserException.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Configuration.Hocon
+namespace Akka.Configuration.Hocon
 {
     public class HoconParserException : Exception
     {

--- a/src/core/Hocon/Configuration/Hocon/HoconRoot.cs
+++ b/src/core/Hocon/Configuration/Hocon/HoconRoot.cs
@@ -8,7 +8,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Configuration.Hocon
+namespace Akka.Configuration.Hocon
 {
     /// <summary>
     /// This class represents the root element in a HOCON (Human-Optimized Config Object Notation)

--- a/src/core/Hocon/Configuration/Hocon/HoconSubstitution.cs
+++ b/src/core/Hocon/Configuration/Hocon/HoconSubstitution.cs
@@ -7,7 +7,7 @@
 
 using System.Collections.Generic;
 
-namespace Configuration.Hocon
+namespace Akka.Configuration.Hocon
 {
     /// <summary>
     /// This class represents a substitution element in a HOCON (Human-Optimized Config Object Notation)

--- a/src/core/Hocon/Configuration/Hocon/HoconToken.cs
+++ b/src/core/Hocon/Configuration/Hocon/HoconToken.cs
@@ -5,7 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Configuration.Hocon
+namespace Akka.Configuration.Hocon
 {
     /// <summary>
     /// This enumeration defines the different types of tokens found within

--- a/src/core/Hocon/Configuration/Hocon/HoconTokenizer.cs
+++ b/src/core/Hocon/Configuration/Hocon/HoconTokenizer.cs
@@ -11,7 +11,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 
-namespace Configuration.Hocon
+namespace Akka.Configuration.Hocon
 {
     /// <summary>
     /// This class contains methods used to tokenize a string.

--- a/src/core/Hocon/Configuration/Hocon/HoconTokenizerException.cs
+++ b/src/core/Hocon/Configuration/Hocon/HoconTokenizerException.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Configuration.Hocon
+namespace Akka.Configuration.Hocon
 {
     public class HoconTokenizerException : Exception
     {

--- a/src/core/Hocon/Configuration/Hocon/HoconValue.cs
+++ b/src/core/Hocon/Configuration/Hocon/HoconValue.cs
@@ -11,7 +11,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 
-namespace Configuration.Hocon
+namespace Akka.Configuration.Hocon
 {
     /// <summary>
     /// This class represents the root type for a HOCON (Human-Optimized Config Object Notation)

--- a/src/core/Hocon/Configuration/Hocon/IHoconElement.cs
+++ b/src/core/Hocon/Configuration/Hocon/IHoconElement.cs
@@ -7,7 +7,7 @@
 
 using System.Collections.Generic;
 
-namespace Configuration.Hocon
+namespace Akka.Configuration.Hocon
 {
     /// <summary>
     /// Marker interface to make it easier to retrieve HOCON

--- a/src/core/Hocon/Properties/AssemblyInfo.cs
+++ b/src/core/Hocon/Properties/AssemblyInfo.cs
@@ -5,12 +5,12 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Hocon")]
+[assembly: AssemblyTitle("Akka.Configuration")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Hocon")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyProduct("Akka.Configuration")]
+[assembly: AssemblyCopyright("Copyright Akka .NET  2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/examples/Fallback/Fallback.csproj
+++ b/src/examples/Fallback/Fallback.csproj
@@ -49,9 +49,9 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\core\Hocon\Akka.csproj">
+    <ProjectReference Include="..\..\core\Hocon\Akka.Hocon.csproj">
       <Project>{4a87ad05-bef2-4b08-bd7e-a9866d88c439}</Project>
-      <Name>Akka</Name>
+      <Name>Akka.Hocon</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/examples/Fallback/Fallback.csproj
+++ b/src/examples/Fallback/Fallback.csproj
@@ -49,9 +49,9 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\core\Hocon\Hocon.csproj">
+    <ProjectReference Include="..\..\core\Hocon\Akka.csproj">
       <Project>{4a87ad05-bef2-4b08-bd7e-a9866d88c439}</Project>
-      <Name>Hocon</Name>
+      <Name>Akka</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/examples/Fallback/Program.cs
+++ b/src/examples/Fallback/Program.cs
@@ -5,7 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-using Configuration;
+using Akka.Configuration;
 using System;
 
 namespace Fallback

--- a/src/examples/HelloHocon/App.config
+++ b/src/examples/HelloHocon/App.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <configSections>
-    <section name="akka" type="Akka.Configuration.Hocon.AkkaConfigurationSection, Akka" />
+    <section name="akka" type="Akka.Configuration.Hocon.AkkaConfigurationSection, Akka.Hocon" />
   </configSections>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />

--- a/src/examples/HelloHocon/App.config
+++ b/src/examples/HelloHocon/App.config
@@ -9,26 +9,8 @@
   <akka>
     <hocon>
       <![CDATA[
-          akka {
-            actor {
-              provider = "Akka.Cluster.ClusterActorRefProvider, Akka.Cluster"
-            }
-            
-            remote {
-              log-remote-lifecycle-events = DEBUG
-              helios.tcp {
-                hostname = "127.0.0.1"
-                port = 0
-              }
-            }
-
-            cluster {
-              seed-nodes = [
-                "akka.tcp://ClusterSystem@127.0.0.1:2551",
-                "akka.tcp://ClusterSystem@127.0.0.1:2552"]
-
-              auto-down-unreachable-after = 30s
-            }
+          root {
+            simple-string = ""Hello Hocon""  
           }
       ]]>
     </hocon>

--- a/src/examples/HelloHocon/HelloHocon.csproj
+++ b/src/examples/HelloHocon/HelloHocon.csproj
@@ -49,9 +49,9 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\core\Hocon\Akka.csproj">
+    <ProjectReference Include="..\..\core\Hocon\Akka.Hocon.csproj">
       <Project>{4a87ad05-bef2-4b08-bd7e-a9866d88c439}</Project>
-      <Name>Akka</Name>
+      <Name>Akka.Hocon</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/examples/HelloHocon/HelloHocon.csproj
+++ b/src/examples/HelloHocon/HelloHocon.csproj
@@ -49,9 +49,9 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\core\Hocon\Hocon.csproj">
+    <ProjectReference Include="..\..\core\Hocon\Akka.csproj">
       <Project>{4a87ad05-bef2-4b08-bd7e-a9866d88c439}</Project>
-      <Name>Hocon</Name>
+      <Name>Akka</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/examples/HelloHocon/Program.cs
+++ b/src/examples/HelloHocon/Program.cs
@@ -5,7 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-using Configuration;
+using Akka.Configuration;
 using System;
 
 namespace HelloHocon
@@ -14,12 +14,7 @@ namespace HelloHocon
     {
         static void Main(string[] args)
         {
-            var hocon = @"
-root {
-  simple-string = ""Hello Hocon""  
-}
-";
-            var config = ConfigurationFactory.ParseString(hocon);
+            var config = ConfigurationFactory.Load();
             var val = config.GetString("root.simple-string");
             Console.WriteLine("Hocon says: " + val);
             Console.ReadKey();

--- a/src/examples/ObjectMerge/ObjectMerge.csproj
+++ b/src/examples/ObjectMerge/ObjectMerge.csproj
@@ -49,9 +49,9 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\core\Hocon\Akka.csproj">
+    <ProjectReference Include="..\..\core\Hocon\Akka.Hocon.csproj">
       <Project>{4a87ad05-bef2-4b08-bd7e-a9866d88c439}</Project>
-      <Name>Akka</Name>
+      <Name>Akka.Hocon</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/examples/ObjectMerge/ObjectMerge.csproj
+++ b/src/examples/ObjectMerge/ObjectMerge.csproj
@@ -49,9 +49,9 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\core\Hocon\Hocon.csproj">
+    <ProjectReference Include="..\..\core\Hocon\Akka.csproj">
       <Project>{4a87ad05-bef2-4b08-bd7e-a9866d88c439}</Project>
-      <Name>Hocon</Name>
+      <Name>Akka</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/examples/ObjectMerge/Program.cs
+++ b/src/examples/ObjectMerge/Program.cs
@@ -5,7 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-using Configuration;
+using Akka.Configuration;
 using System;
 
 namespace ObjectMerge

--- a/src/examples/SimpleSubstitutions/Program.cs
+++ b/src/examples/SimpleSubstitutions/Program.cs
@@ -7,7 +7,7 @@
 
 using System;
 
-using Configuration;
+using Akka.Configuration;
 
 namespace SimpleSubstitutions
 {

--- a/src/examples/SimpleSubstitutions/SimpleSubstitutions.csproj
+++ b/src/examples/SimpleSubstitutions/SimpleSubstitutions.csproj
@@ -49,9 +49,9 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\core\Hocon\Akka.csproj">
+    <ProjectReference Include="..\..\core\Hocon\Akka.Hocon.csproj">
       <Project>{4a87ad05-bef2-4b08-bd7e-a9866d88c439}</Project>
-      <Name>Akka</Name>
+      <Name>Akka.Hocon</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/examples/SimpleSubstitutions/SimpleSubstitutions.csproj
+++ b/src/examples/SimpleSubstitutions/SimpleSubstitutions.csproj
@@ -49,9 +49,9 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\core\Hocon\Hocon.csproj">
+    <ProjectReference Include="..\..\core\Hocon\Akka.csproj">
       <Project>{4a87ad05-bef2-4b08-bd7e-a9866d88c439}</Project>
-      <Name>Hocon</Name>
+      <Name>Akka</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
- Change namespaces to original naming from akka.net
- Move classes back to original folders Configuration and Configuration/Hocon as in akka.net
- Update HelloHocon example to use configuration over getting configuration from string.

Related to #16