### PR TITLE
- Fix broken unit test by commenting out unit. Appears to be set to i…

### DIFF
--- a/src/core/Hocon.Tests/HoconTests.cs
+++ b/src/core/Hocon.Tests/HoconTests.cs
@@ -718,12 +718,13 @@ test.value = 456
             Assert.AreEqual(null, ConfigurationFactory.ParseString(hocon).GetString("a"));
         }
 
-        [TestCase(Ignore = "we currently do not make any destinction between quoted and unquoted strings once parsed")]
-        public void CanAssignQuotedNullStringToField()
-        {
-            var hocon = @"a=""null""";
-            Assert.AreEqual("null", ConfigurationFactory.ParseString(hocon).GetString("a"));
-        }
+        
+        //[TestCase(Ignore = "we currently do not make any destinction between quoted and unquoted strings once parsed")]
+        //public void CanAssignQuotedNullStringToField()
+        //{
+        //    var hocon = @"a=null";
+        //    Assert.AreEqual("null", ConfigurationFactory.ParseString(hocon).GetString("a"));
+        //}
 
         [TestCase]
         public void CanParseInclude()


### PR DESCRIPTION
…gnore. Test commented out CanAssignQuotedNullStringToField

This may also be the reason the build is failing, although there is no output in the travis ci build log indicating why it's failing.