### PR TITLE
Added dependencies to the nuget file

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -97,7 +97,7 @@ Target "RunTests" (fun _ ->
 
 module Nuget = 
     // add Akka dependency for other projects
-    let getAkkaDependency project =
+    let getAkkaDependency =
         ["Newtonsoft.Json", GetPackageVersion "./packages/" "Newtonsoft.Json"]
 
 open Nuget
@@ -161,6 +161,7 @@ let createNugetPackages _ =
             SymbolPackage = NugetSymbolPackage.Nuspec
             Summary = "summary"
             WorkingDir = workingDir
+            Dependencies = getAkkaDependency
              }) 
         nuspec
 


### PR DESCRIPTION
The Newtonsoft dependency wasn't added during the build process. 

I also removed the ```project``` argument from ```getAkkaDependency``` because it is not used... 

Regards
Marc