### PR TITLE
Hocon configuration element collection

### DIFF
--- a/src/Hocon.sln
+++ b/src/Hocon.sln
@@ -1,11 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-<<<<<<< HEAD
-VisualStudioVersion = 14.0.23107.0
-=======
-VisualStudioVersion = 14.0.22823.1
->>>>>>> master
+# Visual Studio 2013
+VisualStudioVersion = 12.0.40629.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Hocon", "core\Hocon\Akka.Hocon.csproj", "{4A87AD05-BEF2-4B08-BD7E-A9866D88C439}"
 EndProject
@@ -24,6 +20,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleSubstitutions", "examples\SimpleSubstitutions\SimpleSubstitutions.csproj", "{06845F4C-E608-4755-B6ED-5A6C775E4DD5}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExternalIncludes", "examples\ExternalIncludes\ExternalIncludes.csproj", "{8ABBD17A-692F-4F21-8945-A4919A86925B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConfigurationFile", "examples\ConfigurationFile\ConfigurationFile.csproj", "{F58ADF0D-8212-498E-AB39-5967C7445D00}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebConfigTransforms", "examples\WebConfigTransforms\WebConfigTransforms.csproj", "{233808AA-8870-4A57-B8FA-6EBE10008C37}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -59,6 +59,14 @@ Global
 		{8ABBD17A-692F-4F21-8945-A4919A86925B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8ABBD17A-692F-4F21-8945-A4919A86925B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8ABBD17A-692F-4F21-8945-A4919A86925B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F58ADF0D-8212-498E-AB39-5967C7445D00}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F58ADF0D-8212-498E-AB39-5967C7445D00}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F58ADF0D-8212-498E-AB39-5967C7445D00}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F58ADF0D-8212-498E-AB39-5967C7445D00}.Release|Any CPU.Build.0 = Release|Any CPU
+		{233808AA-8870-4A57-B8FA-6EBE10008C37}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{233808AA-8870-4A57-B8FA-6EBE10008C37}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{233808AA-8870-4A57-B8FA-6EBE10008C37}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{233808AA-8870-4A57-B8FA-6EBE10008C37}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -71,5 +79,7 @@ Global
 		{0228F9B6-394C-4D6E-A234-EF82C034FBFF} = {633E4227-A565-43B6-BEA8-0F027813FE33}
 		{06845F4C-E608-4755-B6ED-5A6C775E4DD5} = {633E4227-A565-43B6-BEA8-0F027813FE33}
 		{8ABBD17A-692F-4F21-8945-A4919A86925B} = {633E4227-A565-43B6-BEA8-0F027813FE33}
+		{F58ADF0D-8212-498E-AB39-5967C7445D00} = {633E4227-A565-43B6-BEA8-0F027813FE33}
+		{233808AA-8870-4A57-B8FA-6EBE10008C37} = {633E4227-A565-43B6-BEA8-0F027813FE33}
 	EndGlobalSection
 EndGlobal

--- a/src/core/Hocon.Tests/ConfigurationElementSpec.cs
+++ b/src/core/Hocon.Tests/ConfigurationElementSpec.cs
@@ -1,0 +1,77 @@
+﻿﻿//-----------------------------------------------------------------------
+// <copyright file="ConfigurationElementSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Text;
+using Akka.Configuration.Hocon;
+using NUnit.Framework;
+using Akka.Configuration;
+
+namespace Akka.Tests.Configuration
+{
+    [TestFixture]
+    public class ConfigurationElementSpec
+    {
+        [TestCase]
+        public void CanHaveAHoconListElement()
+        {
+            var configMap = new ExeConfigurationFileMap
+            {
+                ExeConfigFilename = @"ConfigurationElementTestData1.config"
+            };
+
+            var testConfiguration = ConfigurationManager.OpenMappedExeConfiguration(configMap, ConfigurationUserLevel.None);
+            var section = testConfiguration.GetSection("testsection") as TestConfigurationSection;
+            Assert.IsNotNull(section);
+
+            var elementCollection = section.HoconList;
+            Assert.IsNotNull(elementCollection);
+            Assert.AreEqual(elementCollection.Count, 3);
+        }
+
+        [TestCase]
+        public void HoconListElementsChainAsFallbacks()
+        {
+            var configMap = new ExeConfigurationFileMap
+            {
+                ExeConfigFilename = @"ConfigurationElementTestData1.config"
+            };
+
+            var testConfiguration = ConfigurationManager.OpenMappedExeConfiguration(configMap, ConfigurationUserLevel.None);
+            var section = testConfiguration.GetSection("testsection") as TestConfigurationSection;
+
+            var config = ConfigurationFactory.FromConfigurationElementCollection(section.HoconList);
+
+            string resulta = config.GetString("root.simple-string-a");
+            Assert.IsNotNull(resulta);
+            Assert.AreEqual(resulta, "A");
+
+            string resultb = config.GetString("root.simple-string-b");
+            Assert.IsNotNull(resultb);
+            Assert.AreEqual(resultb, "B");
+
+            string resultc = config.GetString("root.simple-string-c");
+            Assert.IsNotNull(resultc);
+            Assert.AreEqual(resultc, "C");
+        }
+
+        public class TestConfigurationSection : ConfigurationSection
+        {
+            private const string ConfigurationPropertyName = "hoconlist";
+
+            [ConfigurationProperty(ConfigurationPropertyName, IsRequired = false)]
+            public HoconListConfigurationElementCollection HoconList
+            {
+                get { return (HoconListConfigurationElementCollection)base[ConfigurationPropertyName]; }
+                set { base[ConfigurationPropertyName] = value; }
+            }
+        }
+    }
+}

--- a/src/core/Hocon.Tests/ConfigurationElementTestData1.config
+++ b/src/core/Hocon.Tests/ConfigurationElementTestData1.config
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <configSections>
+    <section name="testsection" type="Akka.Tests.Configuration.ConfigurationElementSpec+TestConfigurationSection, Hocon.Tests" />
+  </configSections>
+  <testsection>
+    <hoconlist>
+      <hocon>
+        <![CDATA[
+          root {
+            simple-string-a = ""A""
+            simple-string-b = ""A""
+            simple-string-c = ""A""
+          }
+        ]]>
+      </hocon>
+      <hocon>
+        <![CDATA[
+          root {
+            simple-string-b = ""B""
+            simple-string-c = ""B""
+          }
+        ]]>
+      </hocon>
+      <hocon>
+        <![CDATA[
+          root {
+            simple-string-c = ""C""
+          }
+        ]]>
+      </hocon>
+    </hoconlist>
+  </testsection>
+</configuration>

--- a/src/core/Hocon.Tests/Hocon.Tests.csproj
+++ b/src/core/Hocon.Tests/Hocon.Tests.csproj
@@ -46,11 +46,15 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssertionExtensions.cs" />
+    <Compile Include="ConfigurationElementSpec.cs" />
     <Compile Include="ConfigurationSpec.cs" />
     <Compile Include="HoconTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="ConfigurationElementTestData1.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/core/Hocon/Akka.Hocon.csproj
+++ b/src/core/Hocon/Akka.Hocon.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Configuration\Hocon\CDataConfigurationElement.cs" />
     <Compile Include="Configuration\Hocon\HoconArray.cs" />
     <Compile Include="Configuration\Hocon\HoconConfigurationElement.cs" />
+    <Compile Include="Configuration\Hocon\HoconListConfigurationElementCollection.cs" />
     <Compile Include="Configuration\Hocon\HoconLiteral.cs" />
     <Compile Include="Configuration\Hocon\HoconObject.cs" />
     <Compile Include="Configuration\Hocon\HoconParserException.cs" />

--- a/src/core/Hocon/Configuration/ConfigurationFactory.cs
+++ b/src/core/Hocon/Configuration/ConfigurationFactory.cs
@@ -139,6 +139,26 @@ namespace Akka.Configuration
             var config = ParseString(json);
             return config;
         }
+
+        /// <summary>
+        /// Creates a configuration based on the supplied source configuration section
+        /// </summary>
+        /// <param name="source">The configuration section</param>
+        /// <returns>The configuration defined in the configuration section.</returns>
+        public static Config FromConfigurationElementCollection(HoconListConfigurationElementCollection source)
+        {
+            if (source == null)
+                throw new ArgumentNullException("source");
+
+            Config result = null;
+
+            foreach (HoconConfigurationElement item in source)
+            {
+                result = new Config(ParseString(item.Content), result);
+            }
+
+            return result ?? Empty;
+        }
     }
 }
 

--- a/src/core/Hocon/Configuration/Hocon/HoconListConfigurationElementCollection.cs
+++ b/src/core/Hocon/Configuration/Hocon/HoconListConfigurationElementCollection.cs
@@ -1,0 +1,96 @@
+﻿﻿//-----------------------------------------------------------------------
+// <copyright file="HoconListConfigurationElementCollection.cs" company="Hocon Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/hocon>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+
+namespace Akka.Configuration.Hocon
+{
+    /// <summary>
+    /// This class represents a list of custom HOCON (Human-Optimized Config Object Notation)
+    /// nodes within a configuration file.
+    /// <code>
+    /// <![CDATA[
+    /// <?xml version="1.0" encoding="utf-8" ?>
+    /// <configuration>
+    ///   <configSections>
+    ///     <section name="akka" type="AkkaConfiguration.Hocon.AkkaConfigurationSection, Akka" />
+    ///   </configSections>
+    ///   <akka>
+    ///     <hocon-list>
+    ///       <hocon>
+    ///       ...
+    ///       </hocon>
+    ///       <hocon>
+    ///       ...
+    ///       </hocon>
+    ///       <hocon>
+    ///       ...
+    ///       </hocon>
+    ///     </hocon-list>
+    ///   </akka>
+    /// </configuration>
+    /// ]]>
+    /// </code>
+    /// </summary>
+    [ConfigurationCollection(typeof(HoconConfigurationElement), AddItemName = "hocon", CollectionType = ConfigurationElementCollectionType.BasicMap)]
+    public class HoconListConfigurationElementCollection : ConfigurationElementCollection
+    {
+        public HoconConfigurationElement this[int index]
+        {
+            get { return (HoconConfigurationElement)BaseGet(index); }
+            set
+            {
+                if (BaseGet(index) != null)
+                {
+                    BaseRemoveAt(index);
+                }
+                BaseAdd(index, value);
+            }
+        }
+
+        public void Add(HoconConfigurationElement serviceConfig)
+        {
+            BaseAdd(serviceConfig);
+        }
+
+        public void Clear()
+        {
+            BaseClear();
+        }
+
+        protected override ConfigurationElement CreateNewElement()
+        {
+            return new HoconConfigurationElement();
+        }
+
+        protected override object GetElementKey(ConfigurationElement element)
+        {
+            return ((HoconConfigurationElement)element).Content;
+        }
+
+        public void Remove(HoconConfigurationElement serviceConfig)
+        {
+            int i = BaseIndexOf(serviceConfig);
+            if (i >= 0)
+            {
+                BaseRemoveAt(i);
+            }
+        }
+
+        public void RemoveAt(int index)
+        {
+            BaseRemoveAt(index);
+        }
+
+        public void Remove(string name)
+        {
+            BaseRemove(name);
+        }
+    }
+}

--- a/src/examples/ConfigurationFile/App.config
+++ b/src/examples/ConfigurationFile/App.config
@@ -1,0 +1,40 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <configSections>
+    <section name="testsection" type="ConfigurationFile.TestConfigurationSection, ConfigurationFile" />
+  </configSections>
+
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+  </startup>
+
+  <testsection>
+    <hoconlist>
+      <hocon>
+        <![CDATA[
+          root {
+            simple-string-a = ""A""
+            simple-string-b = ""A""
+            simple-string-c = ""A""
+          }
+        ]]>
+      </hocon>
+      <hocon>
+        <![CDATA[
+          root {
+            simple-string-b = ""B""
+            simple-string-c = ""B""
+          }
+        ]]>
+      </hocon>
+      <hocon>
+        <![CDATA[
+          root {
+            simple-string-c = ""C""
+          }
+        ]]>
+      </hocon>
+    </hoconlist>
+  </testsection>
+
+</configuration>

--- a/src/examples/ConfigurationFile/ConfigurationFile.csproj
+++ b/src/examples/ConfigurationFile/ConfigurationFile.csproj
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F58ADF0D-8212-498E-AB39-5967C7445D00}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ConfigurationFile</RootNamespace>
+    <AssemblyName>ConfigurationFile</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestConfigurationSection.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\core\Hocon\Akka.Hocon.csproj">
+      <Project>{4a87ad05-bef2-4b08-bd7e-a9866d88c439}</Project>
+      <Name>Akka.Hocon</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/examples/ConfigurationFile/Program.cs
+++ b/src/examples/ConfigurationFile/Program.cs
@@ -1,0 +1,29 @@
+﻿using Akka.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ConfigurationFile
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var section = ConfigurationManager.GetSection("testsection") as TestConfigurationSection;
+            var config = ConfigurationFactory.FromConfigurationElementCollection(section.HoconList);
+
+            string resulta = config.GetString("root.simple-string-a");
+            string resultb = config.GetString("root.simple-string-b");
+            string resultc = config.GetString("root.simple-string-c");
+
+            Console.WriteLine("root.simple-string-a: " + resulta);
+            Console.WriteLine("root.simple-string-b: " + resultb);
+            Console.WriteLine("root.simple-string-c: " + resultc);
+
+            Console.ReadKey();
+        }
+    }
+}

--- a/src/examples/ConfigurationFile/Properties/AssemblyInfo.cs
+++ b/src/examples/ConfigurationFile/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ConfigurationFile")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ConfigurationFile")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("ffdbab65-6ec2-4608-868c-4c89d84fa3e9")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/examples/ConfigurationFile/TestConfigurationSection.cs
+++ b/src/examples/ConfigurationFile/TestConfigurationSection.cs
@@ -1,0 +1,24 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="TestConfigurationSection.cs" company="Hocon Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/hocon>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Configuration.Hocon;
+using System.Configuration;
+
+namespace ConfigurationFile
+{
+    public class TestConfigurationSection : ConfigurationSection
+    {
+        private const string ConfigurationPropertyName = "hoconlist";
+
+        [ConfigurationProperty(ConfigurationPropertyName, IsRequired = false)]
+        public HoconListConfigurationElementCollection HoconList
+        {
+            get { return (HoconListConfigurationElementCollection)base[ConfigurationPropertyName]; }
+            set { base[ConfigurationPropertyName] = value; }
+        }
+    }
+}

--- a/src/examples/WebConfigTransforms/Controllers/HomeController.cs
+++ b/src/examples/WebConfigTransforms/Controllers/HomeController.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Web.Mvc;
+
+namespace WebConfigTransforms.Controllers
+{
+    public class HomeController : Controller
+    {
+        public ActionResult Index()
+        {
+            ViewBag.SimpleString = MvcApplication.HoconConfig.GetString("root.simple-string");
+            return View();
+        }
+    }
+}

--- a/src/examples/WebConfigTransforms/Global.asax
+++ b/src/examples/WebConfigTransforms/Global.asax
@@ -1,0 +1,1 @@
+﻿<%@ Application Codebehind="Global.asax.cs" Inherits="WebConfigTransforms.MvcApplication" Language="C#" %>

--- a/src/examples/WebConfigTransforms/Global.asax.cs
+++ b/src/examples/WebConfigTransforms/Global.asax.cs
@@ -1,0 +1,37 @@
+﻿using Akka.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Web;
+using System.Web.Http;
+using System.Web.Mvc;
+using System.Web.Routing;
+
+namespace WebConfigTransforms
+{
+    public class MvcApplication : System.Web.HttpApplication
+    {
+        public static Config HoconConfig;
+
+        protected void Application_Start()
+        {
+            AreaRegistration.RegisterAllAreas();
+            RegisterRoutes(RouteTable.Routes);
+
+            var section = ConfigurationManager.GetSection("testsection") as TestConfigurationSection;
+            HoconConfig = ConfigurationFactory.FromConfigurationElementCollection(section.HoconList);
+        }
+
+        public static void RegisterRoutes(RouteCollection routes)
+        {
+            routes.IgnoreRoute("{resource}.axd/{*pathInfo}");
+
+            routes.MapRoute(
+                name: "Default",
+                url: "{controller}/{action}/{id}",
+                defaults: new { controller = "Home", action = "Index", id = UrlParameter.Optional }
+            );
+        }
+    }
+}

--- a/src/examples/WebConfigTransforms/Properties/AssemblyInfo.cs
+++ b/src/examples/WebConfigTransforms/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("WebConfigTransforms")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("WebConfigTransforms")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("967c6713-d931-4a39-a8cf-af0f779f9c8b")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Revision and Build Numbers 
+// by using the '*' as shown below:
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/examples/WebConfigTransforms/Properties/PublishProfiles/Dev.pubxml
+++ b/src/examples/WebConfigTransforms/Properties/PublishProfiles/Dev.pubxml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+This file is used by the publish/package process of your Web project. You can customize the behavior of this process
+by editing this MSBuild file. In order to learn more about this please visit http://go.microsoft.com/fwlink/?LinkID=208121. 
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <WebPublishMethod>FileSystem</WebPublishMethod>
+    <LastUsedBuildConfiguration>Debug</LastUsedBuildConfiguration>
+    <LastUsedPlatform>Any CPU</LastUsedPlatform>
+    <SiteUrlToLaunchAfterPublish />
+    <LaunchSiteAfterPublish>True</LaunchSiteAfterPublish>
+    <ExcludeApp_Data>True</ExcludeApp_Data>
+    <publishUrl>./bin/publish</publishUrl>
+    <DeleteExistingFiles>True</DeleteExistingFiles>
+  </PropertyGroup>
+</Project>

--- a/src/examples/WebConfigTransforms/TestConfigurationSection.cs
+++ b/src/examples/WebConfigTransforms/TestConfigurationSection.cs
@@ -1,0 +1,24 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="TestConfigurationSection.cs" company="Hocon Project">
+//     Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+//     Copyright (C) 2013-2015 Akka.NET project <https://github.com/akkadotnet/hocon>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Configuration.Hocon;
+using System.Configuration;
+
+namespace WebConfigTransforms
+{
+    public class TestConfigurationSection : ConfigurationSection
+    {
+        private const string ConfigurationPropertyName = "hoconlist";
+
+        [ConfigurationProperty(ConfigurationPropertyName, IsRequired = false)]
+        public HoconListConfigurationElementCollection HoconList
+        {
+            get { return (HoconListConfigurationElementCollection)base[ConfigurationPropertyName]; }
+            set { base[ConfigurationPropertyName] = value; }
+        }
+    }
+}

--- a/src/examples/WebConfigTransforms/Views/Home/Index.cshtml
+++ b/src/examples/WebConfigTransforms/Views/Home/Index.cshtml
@@ -1,0 +1,5 @@
+﻿@{
+    ViewBag.Title = "Index";
+}
+
+<h1>@ViewBag.SimpleString</h1>

--- a/src/examples/WebConfigTransforms/Views/Shared/_Layout.cshtml
+++ b/src/examples/WebConfigTransforms/Views/Shared/_Layout.cshtml
@@ -1,0 +1,13 @@
+﻿﻿<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>@ViewBag.Title</title>
+</head>
+<body>
+    <div style="margin-left: auto; margin-right: auto;">
+        @RenderBody()
+    </div>
+</body>
+</html>

--- a/src/examples/WebConfigTransforms/Views/Web.config
+++ b/src/examples/WebConfigTransforms/Views/Web.config
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0"?>
+
+<configuration>
+  <configSections>
+    <sectionGroup name="system.web.webPages.razor" type="System.Web.WebPages.Razor.Configuration.RazorWebSectionGroup, System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35">
+      <section name="host" type="System.Web.WebPages.Razor.Configuration.HostSection, System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" requirePermission="false" />
+      <section name="pages" type="System.Web.WebPages.Razor.Configuration.RazorPagesSection, System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" requirePermission="false" />
+    </sectionGroup>
+  </configSections>
+
+  <system.web.webPages.razor>
+    <host factoryType="System.Web.Mvc.MvcWebRazorHostFactory, System.Web.Mvc, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
+    <pages pageBaseType="System.Web.Mvc.WebViewPage">
+      <namespaces>
+        <add namespace="System.Web.Mvc" />
+        <add namespace="System.Web.Mvc.Ajax" />
+        <add namespace="System.Web.Mvc.Html" />
+        <add namespace="System.Web.Optimization"/>
+        <add namespace="System.Web.Routing" />
+      </namespaces>
+    </pages>
+  </system.web.webPages.razor>
+
+  <appSettings>
+    <add key="webpages:Enabled" value="false" />
+  </appSettings>
+
+  <system.web>
+    <httpHandlers>
+      <add path="*" verb="*" type="System.Web.HttpNotFoundHandler"/>
+    </httpHandlers>
+
+    <!--
+        Enabling request validation in view pages would cause validation to occur
+        after the input has already been processed by the controller. By default
+        MVC performs request validation before a controller processes the input.
+        To change this behavior apply the ValidateInputAttribute to a
+        controller or action.
+    -->
+    <pages
+        validateRequest="false"
+        pageParserFilterType="System.Web.Mvc.ViewTypeParserFilter, System.Web.Mvc, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35"
+        pageBaseType="System.Web.Mvc.ViewPage, System.Web.Mvc, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35"
+        userControlBaseType="System.Web.Mvc.ViewUserControl, System.Web.Mvc, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35">
+      <controls>
+        <add assembly="System.Web.Mvc, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" namespace="System.Web.Mvc" tagPrefix="mvc" />
+      </controls>
+    </pages>
+  </system.web>
+
+  <system.webServer>
+    <validation validateIntegratedModeConfiguration="false" />
+
+    <handlers>
+      <remove name="BlockViewHandler"/>
+      <add name="BlockViewHandler" path="*" verb="*" preCondition="integratedMode" type="System.Web.HttpNotFoundHandler" />
+    </handlers>
+  </system.webServer>
+</configuration>

--- a/src/examples/WebConfigTransforms/Views/_ViewStart.cshtml
+++ b/src/examples/WebConfigTransforms/Views/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+﻿@{
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}

--- a/src/examples/WebConfigTransforms/Web.Debug.config
+++ b/src/examples/WebConfigTransforms/Web.Debug.config
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0"?>
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <testsection>
+    <hoconlist>
+      <hocon xdt:Transform="InsertAfter(/configuration/testsection/hoconlist/hocon[1])">
+        <![CDATA[
+          root {
+            simple-string = ""Debug""
+          }
+        ]]>
+      </hocon>
+    </hoconlist>
+  </testsection>
+</configuration>

--- a/src/examples/WebConfigTransforms/Web.Release.config
+++ b/src/examples/WebConfigTransforms/Web.Release.config
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0"?>
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+
+  <system.web>
+    <compilation xdt:Transform="RemoveAttributes(debug)" />
+  </system.web>
+
+  <testsection>
+    <hoconlist>
+      <hocon xdt:Transform="InsertAfter(/configuration/testsection/hoconlist/hocon[1])">
+        <![CDATA[
+          root {
+            simple-string = ""Release""
+          }
+        ]]>
+      </hocon>
+    </hoconlist>
+  </testsection>
+</configuration>

--- a/src/examples/WebConfigTransforms/Web.config
+++ b/src/examples/WebConfigTransforms/Web.config
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <configSections>
+    <section name="testsection" type="WebConfigTransforms.TestConfigurationSection, WebConfigTransforms" />
+  </configSections>
+
+  <appSettings>
+    <add key="webpages:Version" value="2.0.0.0" />
+    <add key="webpages:Enabled" value="false" />
+    <add key="PreserveLoginUrl" value="true" />
+    <add key="ClientValidationEnabled" value="true" />
+    <add key="UnobtrusiveJavaScriptEnabled" value="true" />
+  </appSettings>
+
+  <system.web>
+    <httpRuntime targetFramework="4.5" />
+    <compilation debug="true" targetFramework="4.5" />
+    <pages>
+      <namespaces>
+        <add namespace="System.Web.Helpers" />
+        <add namespace="System.Web.Mvc" />
+        <add namespace="System.Web.Mvc.Ajax" />
+        <add namespace="System.Web.Mvc.Html" />
+        <add namespace="System.Web.Optimization" />
+        <add namespace="System.Web.Routing" />
+        <add namespace="System.Web.WebPages" />
+      </namespaces>
+    </pages>
+  </system.web>
+  
+  <system.webServer>
+    <validation validateIntegratedModeConfiguration="false" />
+  </system.webServer>
+  
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="EntityFramework" publicKeyToken="b77a5c561934e089" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+
+  <testsection>
+    <hoconlist>
+      <hocon>
+        <![CDATA[
+          root {
+            simple-string = ""Base""
+          }
+        ]]>
+      </hocon>
+    </hoconlist>
+  </testsection>
+</configuration>

--- a/src/examples/WebConfigTransforms/WebConfigTransforms.csproj
+++ b/src/examples/WebConfigTransforms/WebConfigTransforms.csproj
@@ -1,0 +1,161 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>
+    </ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{233808AA-8870-4A57-B8FA-6EBE10008C37}</ProjectGuid>
+    <ProjectTypeGuids>{E3E379DF-F4C6-4180-9B81-6769533ABE47};{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>WebConfigTransforms</RootNamespace>
+    <AssemblyName>WebConfigTransforms</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <MvcBuildViews>false</MvcBuildViews>
+    <UseIISExpress>true</UseIISExpress>
+    <IISExpressSSLPort />
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Data.Entity" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Web.Abstractions" />
+    <Reference Include="System.Web.Routing" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Web.Services" />
+    <Reference Include="System.EnterpriseServices" />
+    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http">
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest">
+    </Reference>
+    <Reference Include="System.Web.Mvc, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\..\packages\Microsoft.AspNet.Mvc.4.0.30506.0\lib\net40\System.Web.Mvc.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\..\packages\Microsoft.AspNet.Razor.2.0.30506.0\lib\net40\System.Web.Razor.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.2.0.30506.0\lib\net40\System.Web.WebPages.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Deployment, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.2.0.30506.0\lib\net40\System.Web.WebPages.Deployment.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.2.0.30506.0\lib\net40\System.Web.WebPages.Razor.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Controllers\HomeController.cs" />
+    <Compile Include="Global.asax.cs">
+      <DependentUpon>Global.asax</DependentUpon>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestConfigurationSection.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Global.asax" />
+    <Content Include="Web.config" />
+    <Content Include="Web.Debug.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </Content>
+    <Content Include="Web.Release.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </Content>
+    <Content Include="Views\Web.config" />
+    <Content Include="Views\_ViewStart.cshtml" />
+    <Content Include="Views\Shared\_Layout.cshtml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\Home\Index.cshtml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\core\Hocon\Akka.Hocon.csproj">
+      <Project>{4a87ad05-bef2-4b08-bd7e-a9866d88c439}</Project>
+      <Name>Akka.Hocon</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Properties\PublishProfiles\Dev.pubxml" />
+  </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
+  <Target Name="MvcBuildViews" AfterTargets="AfterBuild" Condition="'$(MvcBuildViews)'=='true'">
+    <AspNetCompiler VirtualPath="temp" PhysicalPath="$(WebProjectOutputDir)" />
+  </Target>
+  <ProjectExtensions>
+    <VisualStudio>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
+        <WebProjectProperties>
+          <UseIIS>True</UseIIS>
+          <AutoAssignPort>True</AutoAssignPort>
+          <DevelopmentServerPort>49400</DevelopmentServerPort>
+          <DevelopmentServerVPath>/</DevelopmentServerVPath>
+          <IISUrl>http://localhost:54455/</IISUrl>
+          <NTLMAuthentication>False</NTLMAuthentication>
+          <UseCustomServer>False</UseCustomServer>
+          <CustomServerUrl>
+          </CustomServerUrl>
+          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+        </WebProjectProperties>
+      </FlavorProperties>
+    </VisualStudio>
+  </ProjectExtensions>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target> -->
+</Project>

--- a/src/examples/WebConfigTransforms/packages.config
+++ b/src/examples/WebConfigTransforms/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.AspNet.Mvc" version="4.0.30506.0" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebPages" version="2.0.30506.0" targetFramework="net45" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
My current project uses standard Asp.Net Web.config files and Web.config Transforms to generate environment specific deployment configurations (e.g. logging, persistence, and cluster configurations).

The Hocon configuration element collection allows the specification of HOCON fallback configurations, using a syntax that can be manipulated by Web.config Transforms or other existing .Net config file management techniques.