### PR TITLE
Substitution ${? features

### DIFF
--- a/src/HOCON/Config.cs
+++ b/src/HOCON/Config.cs
@@ -108,7 +108,7 @@ namespace Hocon
                     if (Fallback != null)
                         return Fallback.GetNode(path);
 
-                    return null;
+                    return HoconValue.Undefined;
                 }
             }
             return currentNode;

--- a/src/HOCON/Hocon.csproj
+++ b/src/HOCON/Hocon.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\common.props" />
 
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.2</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/src/HOCON/Impl/HoconSubstitution.cs
+++ b/src/HOCON/Impl/HoconSubstitution.cs
@@ -5,7 +5,9 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Hocon
 {
@@ -36,15 +38,40 @@ namespace Hocon
         ///     Initializes a new instance of the <see cref="HoconSubstitution" /> class.
         /// </summary>
         /// <param name="path">The path.</param>
-        public HoconSubstitution(string path)
+        public HoconSubstitution(HoconValue parent, string path)
         {
+            Parent = parent ?? throw new ArgumentNullException(nameof(parent), "Hocon substitute parent can not be null.");
+
+            if (path.StartsWith("?"))
+            {
+                IsQuestionMark = true;
+                path = path.Substring(1);
+            }
+
+            Debug.WriteLine($"Path = {path}");
             Path = path;
         }
 
+        public bool IsQuestionMark { get; }
+
+        /// <summary>
+        ///     The Hocon node that owned this substitution node
+        /// </summary>
+        public HoconValue Parent { get; }
+
+        private string _path;
         /// <summary>
         ///     The full path to the value which should substitute this instance.
         /// </summary>
-        public string Path { get; set; }
+        public string Path
+        {
+            get => _path;
+            set
+            {
+                _path = value;
+                Debug.WriteLine($"New path value = {_path}");
+            } 
+        }
 
         /// <summary>
         ///     The evaluated value from the Path property

--- a/src/HOCON/Impl/HoconTokenizer.cs
+++ b/src/HOCON/Impl/HoconTokenizer.cs
@@ -740,6 +740,11 @@ namespace Hocon
             int start = Index;
             var sb = new StringBuilder();
             Take(2);
+
+            // Special case for ${?
+            if (Peek() == '?')
+                sb.Append(Take());
+
             while (!EoF && IsUnquotedText())
             {
                 sb.Append(Take());

--- a/src/HOCON/Impl/HoconValue.cs
+++ b/src/HOCON/Impl/HoconValue.cs
@@ -19,6 +19,13 @@ namespace Hocon
     /// </summary>
     public class HoconValue : IMightBeAHoconObject
     {
+        public static readonly HoconValue Undefined;
+
+        static HoconValue()
+        {
+            Undefined = new HoconValue();
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="HoconValue"/> class.
         /// </summary>
@@ -153,12 +160,12 @@ namespace Hocon
             switch (v)
             {
                 case "on":
+                case "true":
+                case "yes":
                     return true;
                 case "off":
-                    return false;
-                case "true":
-                    return true;
                 case "false":
+                case "no":
                     return false;
                 default:
                     throw new NotSupportedException("Unknown boolean format: " + v);


### PR DESCRIPTION
Related issues: #14 #40 
Add ${? Hocon feature:
- Fallback to environment variable if substitution is unresolved
- Fails silently and removes unresolved field or substituted array items if substitution is unresolved completely

NOTE:  Project moved to standard1.3 for Environment.GetEnvironmentVariable() support