### PR TITLE
Split test files to match HOCON spec document headings to simplify spec conformation - Part 1

### DIFF
--- a/src/HOCON.Tests/Commas.cs
+++ b/src/HOCON.Tests/Commas.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Hocon.Tests
+{
+    public class Commas
+    {
+        /*
+         * Values in arrays, and fields in objects, need not have a comma between them 
+         * as long as they have at least one ASCII newline (\n, decimal value 10) between them.
+         * 
+         * The last element in an array or last field in an object may be followed by a single comma. This extra comma is ignored.
+         */
+
+        // [1, 2, 3,] and [1, 2, 3] are the same array.
+        [Fact]
+        public void ExtraCommaAtTheEndOfArraysIsIgnored()
+        {
+            var hocon = @"
+array_1 : [1, 2, 3, ]
+array_2 : [1, 2, 3]
+";
+            var config = ConfigurationFactory.ParseString(hocon);
+            Assert.True(
+                config.GetIntList("array_1")
+                .SequenceEqual(config.GetIntList("array_2")));
+        }
+
+        // [1\n2\n3] and[1, 2, 3] are the same array.
+        [Fact]
+        public void NewLineCanReplaceCommaInArrays()
+        {
+            var hocon = @"
+array_1 : [
+  1
+  2
+  3 ]
+array_2 : [1, 2, 3]
+";
+            var config = ConfigurationFactory.ParseString(hocon);
+            Assert.True(
+                config.GetIntList("array_1")
+                    .SequenceEqual(config.GetIntList("array_2")));
+        }
+
+        // [1, 2, 3,,] is invalid because it has two trailing commas.
+        [Fact]
+        public void ThrowsParserExceptionOnMultipleTrailingCommasInArray()
+        {
+            var hocon = @"array : [1, 2, 3,, ]";
+            Assert.Throws<HoconParserException>(() => ConfigurationFactory.ParseString(hocon));
+        }
+
+        // [, 1, 2, 3] is invalid because it has an initial comma.
+        [Fact]
+        public void ThrowsParserExceptionOnIllegalCommaInFrontOfArray()
+        {
+            var hocon = @"array : [, 1, 2, 3]";
+            Assert.Throws<HoconParserException>(() => ConfigurationFactory.ParseString(hocon));
+        }
+
+        // [1,, 2, 3] is invalid because it has two commas in a row.
+        [Fact]
+        public void ThrowsParserExceptionOnMultipleCommasInArray()
+        {
+            var hocon = @"array : [1,, 2, 3]";
+            Assert.Throws<HoconParserException>(() => ConfigurationFactory.ParseString(hocon));
+        }
+
+        /*
+         * these same comma rules apply to fields in objects.
+         */
+
+        // {a:1, b:2, c:3,} and {a:1, b:2, c:3} are the same object.
+        [Fact]
+        public void ExtraCommaAtTheEndIgnored()
+        {
+            var hocon_1 = @"a:1, b:2, c:3,";
+            var hocon_2 = @"a:1, b:2, c:3";
+
+            var config_1 = ConfigurationFactory.ParseString(hocon_1);
+            var config_2 = ConfigurationFactory.ParseString(hocon_2);
+            Assert.True(config_1.AsEnumerable().SequenceEqual(config_2.AsEnumerable()));
+        }
+
+        // {a:1\nb:2\nc:3} and {a:1, b:2, c:3} are the same object.
+        [Fact]
+        public void NewLineCanReplaceComma()
+        {
+            var hocon_1 = @"
+a:1
+b:2
+c:3";
+            var hocon_2 = @"a:1, b:2, c:3";
+
+            var config_1 = ConfigurationFactory.ParseString(hocon_1);
+            var config_2 = ConfigurationFactory.ParseString(hocon_2);
+            Assert.True(config_1.AsEnumerable().SequenceEqual(config_2.AsEnumerable()));
+        }
+
+        // {a:1, b:2, c:3,,} is invalid because it has two trailing commas.
+        [Fact]
+        public void ThrowsParserExceptionOnMultipleTrailingCommas()
+        {
+            var hocon = @"{a:1, b:2, c:3,,}";
+            Assert.Throws<HoconParserException>(() => ConfigurationFactory.ParseString(hocon));
+        }
+
+        // {, a:1, b:2, c:3} is invalid because it has an initial comma.
+        [Fact]
+        public void ThrowsParserExceptionOnIllegalCommaInFront()
+        {
+            var hocon = @"{, a:1, b:2, c:3}";
+            Assert.Throws<HoconParserException>(() => ConfigurationFactory.ParseString(hocon));
+        }
+
+        // {a:1,, b:2, c:3} is invalid because it has two commas in a row.
+        [Fact]
+        public void ThrowsParserExceptionOnMultipleCommas()
+        {
+            var hocon = @"{a:1,, b:2, c:3}";
+            Assert.Throws<HoconParserException>(() => ConfigurationFactory.ParseString(hocon));
+        }
+    }
+}

--- a/src/HOCON.Tests/Comments.cs
+++ b/src/HOCON.Tests/Comments.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Hocon.Tests
+{
+    public class Comments
+    {
+        /*
+         * Anything between // or # and the next newline is considered a comment and ignored, 
+         * unless the // or # is inside a quoted string.
+         */
+
+        [Fact]
+        public void CommentsShouldBeIgnored()
+        {
+            var hocon = @"a = 1
+// This should be ignored
+b = 2 // This should be ignored
+# This should be ignored
+c = 3 # This should be ignored";
+            Assert.Equal("2", ConfigurationFactory.ParseString(hocon).GetString("b"));
+            Assert.Equal("3", ConfigurationFactory.ParseString(hocon).GetString("c"));
+        }
+
+        [Fact]
+        public void DoubleSlashOrPoundsInQuotedTextAreNotIgnored()
+        {
+            var hocon = @"a = 1
+b = ""2 // This should not be ignored"" 
+c = ""3 # This should not be ignored"" 
+";
+            Assert.Equal("2 // This should not be ignored", ConfigurationFactory.ParseString(hocon).GetString("b"));
+            Assert.Equal("3 # This should not be ignored", ConfigurationFactory.ParseString(hocon).GetString("c"));
+        }
+    }
+}

--- a/src/HOCON.Tests/DuplicateKeysAndObjectMerging.cs
+++ b/src/HOCON.Tests/DuplicateKeysAndObjectMerging.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Hocon.Tests
+{
+    public class DuplicateKeysAndObjectMerging
+    {
+        /*
+         * duplicate keys that appear later override those that appear earlier, unless both values are objects
+         */
+        [Fact]
+        public void CanOverrideLiteral()
+        {
+            var hocon = @"
+foo : literal
+foo : 42
+";
+            var config = ConfigurationFactory.ParseString(hocon);
+            Assert.Equal(42, config.GetInt("foo"));
+        }
+
+        /*
+         * If both values are objects, then the objects are merged.
+         */
+
+        // add fields present in only one of the two objects to the merged object.
+        [Fact]
+        public void CanMergeObject_DifferentFields()
+        {
+            var hocon = @"
+foo : { a : 42 },
+foo : { b : 43 }
+";
+
+            var config = ConfigurationFactory.ParseString(hocon);
+            Assert.Equal(42, config.GetInt("foo.a"));
+            Assert.Equal(43, config.GetInt("foo.b"));
+        }
+
+        // for non-object-valued fields present in both objects, the field found in the second object must be used.
+        [Fact]
+        public void CanMergeObject_SameField()
+        {
+            var hocon = @"
+foo : { a : 42 },
+foo : { a : 43 }
+";
+
+            var config = ConfigurationFactory.ParseString(hocon);
+            Assert.Equal(43, config.GetInt("foo.a"));
+        }
+
+        // for object-valued fields present in both objects, the object values should be recursively merged according to these same rules.
+        [Fact]
+        public void CanMergeObject_RecursiveMerging()
+        {
+            var hocon = @"
+foo
+{
+  bar 
+  {
+    a : 42
+    b : 43 
+  }
+},
+foo
+{ 
+  bar
+  {
+    b : 44
+    c : 45
+    baz
+    {
+      a : 9000
+    }
+  }
+}
+";
+
+            var config = ConfigurationFactory.ParseString(hocon);
+            Assert.Equal(42, config.GetInt("foo.bar.a"));
+            Assert.Equal(44, config.GetInt("foo.bar.b"));
+            Assert.Equal(45, config.GetInt("foo.bar.c"));
+            Assert.Equal(9000, config.GetInt("foo.bar.baz.a"));
+        }
+
+        // Assigning an object field to a literal and then to another object would prevent merging
+        [Fact]
+        public void CanOverrideObject()
+        {
+            var hocon = @"
+{
+    foo : { a : 42 },
+    foo : null,
+    foo : { b : 43 }
+}";
+            var config = ConfigurationFactory.ParseString(hocon);
+            Assert.False(config.HasPath("foo.a"));
+            Assert.Equal(43, config.GetInt("foo.b"));
+        }
+
+    }
+}

--- a/src/HOCON.Tests/HoconTests.cs
+++ b/src/HOCON.Tests/HoconTests.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using FluentAssertions;
 using Xunit;
 
+
 namespace Hocon.Tests
 {
     public class HoconTests

--- a/src/HOCON.Tests/HoconTests.cs
+++ b/src/HOCON.Tests/HoconTests.cs
@@ -296,18 +296,6 @@ a.b.e.f=3
         }
 
         [Fact]
-        public void CanAssignSubstitutionToField()
-        {
-            var hocon = @"a{
-    b = 1
-    c = ${a.b}
-    d = ${a.c}23
-}";
-            Assert.Equal(1, ConfigurationFactory.ParseString(hocon).GetInt("a.c"));
-            Assert.Equal(123, ConfigurationFactory.ParseString(hocon).GetInt("a.d"));
-        }
-
-        [Fact]
         public void CanAssignDoubleToField()
         {
             var hocon = @"a=1.1";
@@ -588,24 +576,6 @@ test.value = 456
         }
 
         [Fact]
-        public void CanCSubstituteObject()
-        {
-            var hocon = @"a {
-  b {
-      foo = hello
-      bar = 123
-  }
-  c {
-     d = xyz
-     e = ${a.b}
-  }  
-}";
-            var ace = ConfigurationFactory.ParseString(hocon).GetConfig("a.c.e");
-            Assert.Equal("hello", ace.GetString("foo"));
-            Assert.Equal(123, ace.GetInt("bar"));
-        }
-
-        [Fact]
         public void CanAssignNullStringToField()
         {
             var hocon = @"a=null";
@@ -631,55 +601,10 @@ x = 123
 y = hello
 ";
             Func<string, HoconRoot> include = s => Parser.Parse(includeHocon, null);
-            var config = ConfigurationFactory.ParseString(hocon,include);
-
-            Assert.Equal(123,config.GetInt("a.b.x"));
-            Assert.Equal("hello", config.GetString("a.b.y"));
-        }
-
-        [Fact]
-        public void CanResolveSubstitutesInInclude()
-        {
-            var hocon = @"a {
-  b { 
-       include ""foo""
-  }";
-            var includeHocon = @"
-x = 123
-y = ${x}
-";
-            Func<string, HoconRoot> include = s => Parser.Parse(includeHocon, null);
             var config = ConfigurationFactory.ParseString(hocon, include);
 
             Assert.Equal(123, config.GetInt("a.b.x"));
-            Assert.Equal(123, config.GetInt("a.b.y"));
-        }
-
-        [Fact]
-        public void CanResolveSubstitutesInNestedIncludes()
-        {
-            var hocon = @"a.b.c {
-  d { 
-       include ""foo""
-  }";
-            var includeHocon = @"
-f = 123
-e {
-      include ""foo""
-}
-";
-
-            var includeHocon2 = @"
-x = 123
-y = ${x}
-";
-
-            Func<string, HoconRoot> include2 = s => Parser.Parse(includeHocon2, null);
-            Func<string, HoconRoot> include = s => Parser.Parse(includeHocon, include2);
-            var config = ConfigurationFactory.ParseString(hocon, include);
-
-            Assert.Equal(123, config.GetInt("a.b.c.d.e.x"));
-            Assert.Equal(123, config.GetInt("a.b.c.d.e.y"));
+            Assert.Equal("hello", config.GetString("a.b.y"));
         }
     }
 }

--- a/src/HOCON.Tests/HoconTests.cs
+++ b/src/HOCON.Tests/HoconTests.cs
@@ -34,22 +34,6 @@ a {
         }
 
         [Fact]
-        public void ThrowsParserExceptionOnUnterminatedObject() //undefined behavior in spec
-        {
-            var hocon = " root { string : \"hello\" ";
-            Assert.Throws<HoconParserException>(() => 
-                ConfigurationFactory.ParseString(hocon));
-        }
-
-        [Fact]
-        public void ThrowsParserExceptionOnUnterminatedNestedObject() //undefined behavior in spec
-        {
-            var hocon = " root { bar { string : \"hello\" } ";
-            Assert.Throws<HoconParserException>(() =>
-                ConfigurationFactory.ParseString(hocon));
-        }
-
-        [Fact]
         public void ThrowsParserExceptionOnUnterminatedString() //undefined behavior in spec
         {
             var hocon = " string : \"hello";
@@ -162,62 +146,6 @@ a {
 
 
         [Fact]
-        public void CanConcatenateSubstitutedUnquotedString()
-        {
-            var hocon = @"a {
-  name = Roger
-  c = Hello my name is ${a.name}
-}";
-            Assert.Equal("Hello my name is Roger", ConfigurationFactory.ParseString(hocon).GetString("a.c"));
-        }
-
-        [Fact]
-        public void CanConcatenateSubstitutedArray()
-        {
-            var hocon = @"a {
-  b = [1,2,3]
-  c = ${a.b} [4,5,6]
-}";
-            Assert.True(new[] {1, 2, 3, 4, 5, 6}.SequenceEqual(ConfigurationFactory.ParseString(hocon).GetIntList("a.c")));
-        }
-
-        [Fact]
-        public void SubtitutedArrayWithQuestionMarkShouldFailSilently()
-        {
-            var hocon = @"a {
-  c = ${?a.b} [4,5,6]
-}";
-            Assert.True(new[] { 4, 5, 6 }.SequenceEqual(ConfigurationFactory.ParseString(hocon).GetIntList("a.c")));
-        }
-
-        [Fact]
-        public void SubstitutionWithQuestionMarkShouldFailSilently()
-        {
-            var hocon = @"a {
-  b = ${?a.c}
-}";
-            ConfigurationFactory.ParseString(hocon);
-        }
-
-        [Fact]
-        public void SubstitutionWithQuestionMarkShouldFallbackToEnvironmentVariables()
-        {
-            var hocon = @"a {
-  b = ${?MY_ENV_VAR}
-}";
-            var value = "Environment_Var";
-            Environment.SetEnvironmentVariable("MY_ENV_VAR", value);
-            try
-            {
-                Assert.Equal(value, ConfigurationFactory.ParseString(hocon).GetString("a.b"));
-            }
-            finally
-            {
-                Environment.SetEnvironmentVariable("MY_ENV_VAR", null);
-            }
-        }
-
-        [Fact]
         public void CanParseSubConfig()
         {
             var hocon = @"
@@ -231,77 +159,6 @@ a {
             var subConfig = config.GetConfig("a");
             Assert.Equal(1, subConfig.GetInt("b.c"));
             Assert.True(subConfig.GetBoolean("b.d"));
-        }
-
-        [Fact]
-        public void CanParseHocon()
-        {
-            var hocon = @"
-root {
-  int = 1
-  quoted-string = ""foo""
-  unquoted-string = bar
-  concat-string = foo bar
-  object {
-    hasContent = true
-  }
-  array = [1,2,3,4]
-  array-concat = [[1,2] [3,4]]
-  array-single-element = [1 2 3 4]
-  array-newline-element = [
-    1
-    2
-    3
-    4
-  ]
-  null = null
-  double = 1.23
-  bool = true
-}
-";
-            var config = ConfigurationFactory.ParseString(hocon);
-            Assert.Equal("1", config.GetString("root.int"));
-            Assert.Equal("1.23", config.GetString("root.double"));
-            Assert.Equal(true, config.GetBoolean("root.bool"));
-            Assert.Equal(true, config.GetBoolean("root.object.hasContent"));
-            Assert.Equal(null, config.GetString("root.null"));
-            Assert.Equal("foo", config.GetString("root.quoted-string"));
-            Assert.Equal("bar", config.GetString("root.unquoted-string"));
-            Assert.Equal("foo bar", config.GetString("root.concat-string"));
-            Assert.True(
-                new[] {1, 2, 3, 4}.SequenceEqual(ConfigurationFactory.ParseString(hocon).GetIntList("root.array")));
-            Assert.True(
-                new[] {1, 2, 3, 4}.SequenceEqual(
-                    ConfigurationFactory.ParseString(hocon).GetIntList("root.array-newline-element")));
-            Assert.True(
-                new[] {"1 2 3 4"}.SequenceEqual(
-                    ConfigurationFactory.ParseString(hocon).GetStringList("root.array-single-element")));
-        }
-
-        [Fact]
-        public void CanParseJson()
-        {
-            var hocon = @"
-""root"" : {
-  ""int"" : 1,
-  ""string"" : ""foo"",
-  ""object"" : {
-        ""hasContent"" : true
-    },
-  ""array"" : [1,2,3],
-  ""null"" : null,
-  ""double"" : 1.23,
-  ""bool"" : true
-}
-";
-            var config = ConfigurationFactory.ParseString(hocon);
-            Assert.Equal("1", config.GetString("root.int"));
-            Assert.Equal("1.23", config.GetString("root.double"));
-            Assert.Equal(true, config.GetBoolean("root.bool"));
-            Assert.Equal(true, config.GetBoolean("root.object.hasContent"));
-            Assert.Equal(null, config.GetString("root.null"));
-            Assert.Equal("foo", config.GetString("root.string"));
-            Assert.True(new[] {1, 2, 3}.SequenceEqual(ConfigurationFactory.ParseString(hocon).GetIntList("root.array")));
         }
 
         [Fact]
@@ -475,6 +332,11 @@ a.b.e.f=3
             hocon = @"a=on";
             Assert.True(ConfigurationFactory.ParseString(hocon).GetBoolean("a"));
             hocon = @"a=off";
+            Assert.False(ConfigurationFactory.ParseString(hocon).GetBoolean("a"));
+
+            hocon = @"a=yes";
+            Assert.True(ConfigurationFactory.ParseString(hocon).GetBoolean("a"));
+            hocon = @"a=no";
             Assert.False(ConfigurationFactory.ParseString(hocon).GetBoolean("a"));
         }
 
@@ -747,7 +609,7 @@ test.value = 456
         public void CanAssignNullStringToField()
         {
             var hocon = @"a=null";
-            Assert.Equal(null, ConfigurationFactory.ParseString(hocon).GetString("a"));
+            Assert.Null(ConfigurationFactory.ParseString(hocon).GetString("a"));
         }
 
         [Fact(Skip = "we currently do not make any destinction between quoted and unquoted strings once parsed")]

--- a/src/HOCON.Tests/KeyValueSeparator.cs
+++ b/src/HOCON.Tests/KeyValueSeparator.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Hocon.Tests
+{
+    public class KeyValueSeparator
+    {
+        /*
+         * The = character can be used anywhere JSON allows :, i.e. to separate keys from values.
+         */
+        [Fact]
+        public void CanParseHoconWithEqualsOrColonSeparator()
+        {
+            var hocon = @"
+root {
+  int = 1
+  quoted-string = ""foo""
+  unquoted-string = bar
+  concat-string = foo bar
+  object {
+    hasContent = true
+  }
+  array = [1,2,3,4]
+  array-concat = [[1,2] [3,4]]
+  array-single-element : [1 2 3 4]
+  array-newline-element : [
+    1
+    2
+    3
+    4
+  ]
+  null : null
+  double : 1.23
+  bool : true
+}
+root_2 : 1234
+";
+            var config = ConfigurationFactory.ParseString(hocon);
+            Assert.Equal("1", config.GetString("root.int"));
+            Assert.Equal("1.23", config.GetString("root.double"));
+            Assert.True(config.GetBoolean("root.bool"));
+            Assert.True(config.GetBoolean("root.object.hasContent"));
+            Assert.Null(config.GetString("root.null"));
+            Assert.Equal("foo", config.GetString("root.quoted-string"));
+            Assert.Equal("bar", config.GetString("root.unquoted-string"));
+            Assert.Equal("foo bar", config.GetString("root.concat-string"));
+            Assert.True(
+                new[] { 1, 2, 3, 4 }.SequenceEqual(ConfigurationFactory.ParseString(hocon).GetIntList("root.array")));
+            Assert.True(
+                new[] { 1, 2, 3, 4 }.SequenceEqual(
+                    ConfigurationFactory.ParseString(hocon).GetIntList("root.array-newline-element")));
+            Assert.True(
+                new[] { "1 2 3 4" }.SequenceEqual(
+                    ConfigurationFactory.ParseString(hocon).GetStringList("root.array-single-element")));
+            Assert.Equal("1234", config.GetString("root_2"));
+        }
+
+        /*
+         * If a key is followed by {, the : or = may be omitted. So "foo" {} means "foo" : {}
+         */
+        [Fact]
+        public void CanParseHoconWithSeparatorForObjectFieldAssignment()
+        {
+            var hocon = @"
+root = {
+  int = 1
+}
+root_2 : {
+  unquoted-string = bar
+}
+";
+            var config = ConfigurationFactory.ParseString(hocon);
+            Assert.Equal("1", config.GetString("root.int"));
+            Assert.Equal("bar", config.GetString("root_2.unquoted-string"));
+        }
+
+    }
+}

--- a/src/HOCON.Tests/OmitRootBraces.cs
+++ b/src/HOCON.Tests/OmitRootBraces.cs
@@ -1,0 +1,224 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Hocon.Tests
+{
+    public class OmitRootBraces
+    {
+        /*
+         * Empty files are invalid documents.
+         */
+        [Fact]
+        public void EmptyFilesShouldThrows()
+        {
+            Assert.Throws<HoconParserException>(() => ConfigurationFactory.ParseString(""));
+            Assert.Throws<HoconParserException>(() => ConfigurationFactory.ParseString(null));
+        }
+
+        /* 
+         * Files containing only a non-array non-object value such as a string are invalid.
+         */
+        [Fact]
+        public void FileWithLiteralOnlyShouldThrows()
+        {
+            Assert.Throws<HoconParserException>(() => ConfigurationFactory.ParseString("literal"));
+            Assert.Throws<HoconParserException>(() => ConfigurationFactory.ParseString("${?path}"));
+        }
+
+        /*
+         *  If the file does not begin with a square bracket or curly brace, 
+         *  it is parsed as if it were enclosed with {} curly braces.
+         */
+        [Fact]
+        public void CanParseJson()
+        {
+            var hocon = @"{
+  ""root"" : {
+    ""int"" : 1,
+    ""string"" : ""foo"",
+    ""object"" : {
+      ""hasContent"" : true
+    },
+    ""array"" : [1,2,3],
+    ""null"" : null,
+    ""double"" : 1.23,
+    ""bool"" : true
+  },
+  ""root_2"" : 1234
+}";
+            var config = ConfigurationFactory.ParseString(hocon);
+            Assert.Equal("1", config.GetString("root.int"));
+            Assert.Equal("1.23", config.GetString("root.double"));
+            Assert.True(config.GetBoolean("root.bool"));
+            Assert.True(config.GetBoolean("root.object.hasContent"));
+            Assert.Null(config.GetString("root.null"));
+            Assert.Equal("foo", config.GetString("root.string"));
+            Assert.True(new[] { 1, 2, 3 }.SequenceEqual(ConfigurationFactory.ParseString(hocon).GetIntList("root.array")));
+            Assert.Equal("1234", config.GetString("root_2"));
+        }
+
+        [Fact]
+        public void CanParseJsonWithNoRootBraces()
+        {
+            var hocon = @"
+""root"" : {
+  ""int"" : 1,
+  ""string"" : ""foo"",
+  ""object"" : {
+    ""hasContent"" : true
+  },
+  ""array"" : [1,2,3],
+  ""null"" : null,
+  ""double"" : 1.23,
+  ""bool"" : true
+},
+""root_2"" : 1234";
+            var config = ConfigurationFactory.ParseString(hocon);
+            Assert.Equal("1", config.GetString("root.int"));
+            Assert.Equal("1.23", config.GetString("root.double"));
+            Assert.True(config.GetBoolean("root.bool"));
+            Assert.True(config.GetBoolean("root.object.hasContent"));
+            Assert.Null(config.GetString("root.null"));
+            Assert.Equal("foo", config.GetString("root.string"));
+            Assert.True(new[] { 1, 2, 3 }.SequenceEqual(ConfigurationFactory.ParseString(hocon).GetIntList("root.array")));
+            Assert.Equal("1234", config.GetString("root_2"));
+        }
+
+        [Fact]
+        public void CanParseHocon()
+        {
+            var hocon = @"
+root {
+  int = 1
+  quoted-string = ""foo""
+  unquoted-string = bar
+  concat-string = foo bar
+  object {
+    hasContent = true
+  }
+  array = [1,2,3,4]
+  array-concat = [[1,2] [3,4]]
+  array-single-element = [1 2 3 4]
+  array-newline-element = [
+    1
+    2
+    3
+    4
+  ]
+  null = null
+  double = 1.23
+  bool = true
+}
+root_2 = 1234
+";
+            var config = ConfigurationFactory.ParseString(hocon);
+            Assert.Equal("1", config.GetString("root.int"));
+            Assert.Equal("1.23", config.GetString("root.double"));
+            Assert.True(config.GetBoolean("root.bool"));
+            Assert.True(config.GetBoolean("root.object.hasContent"));
+            Assert.Null(config.GetString("root.null"));
+            Assert.Equal("foo", config.GetString("root.quoted-string"));
+            Assert.Equal("bar", config.GetString("root.unquoted-string"));
+            Assert.Equal("foo bar", config.GetString("root.concat-string"));
+            Assert.True(
+                new[] { 1, 2, 3, 4 }.SequenceEqual(ConfigurationFactory.ParseString(hocon).GetIntList("root.array")));
+            Assert.True(
+                new[] { 1, 2, 3, 4 }.SequenceEqual(
+                    ConfigurationFactory.ParseString(hocon).GetIntList("root.array-newline-element")));
+            Assert.True(
+                new[] { "1 2 3 4" }.SequenceEqual(
+                    ConfigurationFactory.ParseString(hocon).GetStringList("root.array-single-element")));
+            Assert.Equal("1234", config.GetString("root_2"));
+        }
+
+        [Fact]
+        public void CanParseHoconWithRootBraces()
+        {
+            var hocon = @"
+{
+  root {
+    int = 1
+    quoted-string = ""foo""
+    unquoted-string = bar
+    concat-string = foo bar
+    object {
+      hasContent = true
+    }
+    array = [1,2,3,4]
+    array-concat = [[1,2] [3,4]]
+    array-single-element = [1 2 3 4]
+    array-newline-element = [
+      1
+      2
+      3
+      4
+    ]
+    null = null
+    double = 1.23
+    bool = true
+  }
+  root_2 : 1234
+}";
+            var config = ConfigurationFactory.ParseString(hocon);
+            Assert.Equal("1", config.GetString("root.int"));
+            Assert.Equal("1.23", config.GetString("root.double"));
+            Assert.True(config.GetBoolean("root.bool"));
+            Assert.True(config.GetBoolean("root.object.hasContent"));
+            Assert.Null(config.GetString("root.null"));
+            Assert.Equal("foo", config.GetString("root.quoted-string"));
+            Assert.Equal("bar", config.GetString("root.unquoted-string"));
+            Assert.Equal("foo bar", config.GetString("root.concat-string"));
+            Assert.True(
+                new[] { 1, 2, 3, 4 }.SequenceEqual(ConfigurationFactory.ParseString(hocon).GetIntList("root.array")));
+            Assert.True(
+                new[] { 1, 2, 3, 4 }.SequenceEqual(
+                    ConfigurationFactory.ParseString(hocon).GetIntList("root.array-newline-element")));
+            Assert.True(
+                new[] { "1 2 3 4" }.SequenceEqual(
+                    ConfigurationFactory.ParseString(hocon).GetStringList("root.array-single-element")));
+            Assert.Equal("1234", config.GetString("root_2"));
+        }
+
+        /*
+         * A HOCON file is invalid if it omits the opening { but still has a closing }
+         * the curly braces must be balanced.
+         */
+
+        [Fact]
+        public void ThrowsParserExceptionOnUnterminatedFile()
+        {
+            var hocon = "{ root { string : \"hello\" }";
+            Assert.Throws<HoconParserException>(() =>
+                ConfigurationFactory.ParseString(hocon));
+        }
+
+        [Fact]
+        public void ThrowsParserExceptionOnInvalidTerminatedFile()
+        {
+            var hocon = "root { string : \"hello\" }}";
+            Assert.Throws<HoconParserException>(() =>
+                ConfigurationFactory.ParseString(hocon));
+        }
+
+        [Fact]
+        public void ThrowsParserExceptionOnUnterminatedObject()
+        {
+            var hocon = " root { string : \"hello\" ";
+            Assert.Throws<HoconParserException>(() =>
+                ConfigurationFactory.ParseString(hocon));
+        }
+
+        [Fact]
+        public void ThrowsParserExceptionOnUnterminatedNestedObject()
+        {
+            var hocon = " root { bar { string : \"hello\" } ";
+            Assert.Throws<HoconParserException>(() =>
+                ConfigurationFactory.ParseString(hocon));
+        }
+
+    }
+}

--- a/src/HOCON.Tests/Substitution.cs
+++ b/src/HOCON.Tests/Substitution.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Hocon.Tests
+{
+    public class Substitution
+    {
+        [Fact]
+        public void CanConcatenateUnquotedString()
+        {
+            var hocon = @"a {
+  name = Roger
+  c = Hello my name is ${a.name}
+}";
+            Assert.Equal("Hello my name is Roger", ConfigurationFactory.ParseString(hocon).GetString("a.c"));
+        }
+
+        [Fact(Skip = "Currently not working as spec.")]
+        public void CanConcatenateQuotedString()
+        {
+            var hocon = @"a {
+  name = Roger
+  c = ""Hello my name is "" ${a.name}
+}";
+            Assert.Equal("Hello my name is Roger", ConfigurationFactory.ParseString(hocon).GetString("a.c"));
+        }
+
+        [Fact]
+        public void CanConcatenateArray()
+        {
+            var hocon = @"a {
+  b = [1,2,3]
+  c = ${a.b} [4,5,6]
+}";
+            Assert.True(new[] { 1, 2, 3, 4, 5, 6 }.SequenceEqual(ConfigurationFactory.ParseString(hocon).GetIntList("a.c")));
+        }
+
+        [Fact]
+        public void QuestionMarkConcatenateArrayShouldFailSilently()
+        {
+            var hocon = @"a {
+  c = ${?a.b} [4,5,6]
+}";
+            Assert.True(new[] { 4, 5, 6 }.SequenceEqual(ConfigurationFactory.ParseString(hocon).GetIntList("a.c")));
+        }
+
+        [Fact]
+        public void QuestionMarkShouldFailSilently()
+        {
+            var hocon = @"a {
+  b = ${?a.c}
+}";
+            ConfigurationFactory.ParseString(hocon);
+        }
+
+        [Fact]
+        public void QuestionMarkShouldFallbackToEnvironmentVariables()
+        {
+            var hocon = @"a {
+  b = ${?MY_ENV_VAR}
+}";
+            var value = "Environment_Var";
+            Environment.SetEnvironmentVariable("MY_ENV_VAR", value);
+            try
+            {
+                Assert.Equal(value, ConfigurationFactory.ParseString(hocon).GetString("a.b"));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("MY_ENV_VAR", null);
+            }
+        }
+
+
+    }
+}

--- a/src/HOCON.Tests/Substitution.cs
+++ b/src/HOCON.Tests/Substitution.cs
@@ -19,12 +19,12 @@ namespace Hocon.Tests
             Assert.Equal("Hello my name is Roger", ConfigurationFactory.ParseString(hocon).GetString("a.c"));
         }
 
-        [Fact(Skip = "Currently not working as spec.")]
+        [Fact]
         public void CanConcatenateQuotedString()
         {
             var hocon = @"a {
   name = Roger
-  c = ""Hello my name is "" ${a.name}
+  c = ""Hello my name is ""${a.name}
 }";
             Assert.Equal("Hello my name is Roger", ConfigurationFactory.ParseString(hocon).GetString("a.c"));
         }

--- a/src/HOCON.Tests/Substitution.cs
+++ b/src/HOCON.Tests/Substitution.cs
@@ -9,52 +9,61 @@ namespace Hocon.Tests
 {
     public class Substitution
     {
+        /*
+         * FACT:
+         * The syntax is ${pathexpression} or ${?pathexpression}
+         */
+
+        /*
+         * FACT:
+         * The two characters ${ must be exactly like that, grouped together.
+         */
         [Fact]
-        public void CanConcatenateUnquotedString()
+        public void ThrowsOnInvalidSubstitutionStartToken()
         {
-            var hocon = @"a {
-  name = Roger
-  c = Hello my name is ${a.name}
+            var hocon = @"a{
+    b = 1
+    c = $ {a.b}
 }";
-            Assert.Equal("Hello my name is Roger", ConfigurationFactory.ParseString(hocon).GetString("a.c"));
+            Assert.Throws<HoconParserException>(() => ConfigurationFactory.ParseString(hocon));
         }
 
+        /*
+         * FACT:
+         * - The ? in ${?pathexpression} must not have whitespace before it
+         * - The three characters ${? must be exactly like that, grouped together.
+         */
         [Fact]
-        public void CanConcatenateQuotedString()
+        public void ThrowsOnInvalidSubstitutionWithQuestionMarkStartToken()
         {
-            var hocon = @"a {
-  name = Roger
-  c = ""Hello my name is ""${a.name}
+            var hocon = @"a{
+    b = 1
+    c = ${ ?a.b}
 }";
-            Assert.Equal("Hello my name is Roger", ConfigurationFactory.ParseString(hocon).GetString("a.c"));
+            Assert.Throws<HoconParserException>(() => ConfigurationFactory.ParseString(hocon));
         }
 
+        /*
+         * FACT:
+         * For substitutions which are not found in the configuration tree, 
+         * implementations may try to resolve them by looking at system environment variables.
+         */
         [Fact]
-        public void CanConcatenateArray()
+        public void ShouldFallbackToEnvironmentVariables()
         {
             var hocon = @"a {
-  b = [1,2,3]
-  c = ${a.b} [4,5,6]
+  b = ${MY_ENV_VAR}
 }";
-            Assert.True(new[] { 1, 2, 3, 4, 5, 6 }.SequenceEqual(ConfigurationFactory.ParseString(hocon).GetIntList("a.c")));
-        }
-
-        [Fact]
-        public void QuestionMarkConcatenateArrayShouldFailSilently()
-        {
-            var hocon = @"a {
-  c = ${?a.b} [4,5,6]
-}";
-            Assert.True(new[] { 4, 5, 6 }.SequenceEqual(ConfigurationFactory.ParseString(hocon).GetIntList("a.c")));
-        }
-
-        [Fact]
-        public void QuestionMarkShouldFailSilently()
-        {
-            var hocon = @"a {
-  b = ${?a.c}
-}";
-            ConfigurationFactory.ParseString(hocon);
+            var value = "Environment_Var";
+            Environment.SetEnvironmentVariable("MY_ENV_VAR", value);
+            try
+            {
+                Assert.Equal(value, ConfigurationFactory.ParseString(hocon).GetString("a.b"));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("MY_ENV_VAR", null);
+            }
         }
 
         [Fact]
@@ -75,6 +84,441 @@ namespace Hocon.Tests
             }
         }
 
+        /*
+         * FACT:
+         * For substitutions which are not found in the configuration tree, 
+         * implementations may try to resolve them by looking at other external sources of configuration.
+         */
+        // TODO: Create external config file lookup and loading implementation
 
+        /*
+         * FACT:
+         * Substitutions are not parsed inside quoted strings.
+         */
+        [Fact]
+        public void DoNotParseSubstitutionInsideQuotedString()
+        {
+            var hocon = @"a{
+    b = 5
+    c = ""I have ${a.b} Tesla car(s).""
+}";
+            Assert.Equal("I have ${a.b} Tesla car(s).", ConfigurationFactory.ParseString(hocon).GetString("a.c"));
+        }
+
+        /*
+         * FACT:
+         * To get a string containing a substitution, 
+         * you must use value concatenation with the substitution in the unquoted portion
+         */
+        [Fact]
+        public void CanConcatenateUnquotedString()
+        {
+            var hocon = @"a {
+  name = Roger
+  c = Hello my name is ${a.name}
+}";
+            Assert.Equal("Hello my name is Roger", ConfigurationFactory.ParseString(hocon).GetString("a.c"));
+        }
+
+        /*
+         * FACT:
+         * or can use value concatenation of a substitution and a quoted string.
+         */
+        [Fact]
+        public void CanConcatenateQuotedString()
+        {
+            var hocon = @"a {
+  name = Roger
+  c = ""Hello my name is ""${a.name}
+}";
+            Assert.Equal("Hello my name is Roger", ConfigurationFactory.ParseString(hocon).GetString("a.c"));
+        }
+
+        /*
+         * FACT:
+         * Substitutions are resolved by looking up the path in the configuration. 
+         * The path begins with the root configuration object, i.e. it is "absolute" rather than "relative."
+         */
+        // TODO: Is this test-able?
+
+        /*
+         * FACT:
+         * Substitution processing is performed as the last parsing step, 
+         * so a substitution can look forward in the configuration. 
+         * If a configuration consists of multiple files, 
+         * it may even end up retrieving a value from another file.
+         */
+        [Fact]
+        public void SubstitutionShouldLookForwardInConfiguration()
+        {
+            var hocon = @"a{
+    b = ${a.c}
+    c = 42
+}";
+            var config = ConfigurationFactory.ParseString(hocon);
+            Assert.Equal(42, config.GetInt("a.b"));
+        }
+
+        [Fact]
+        public void CanResolveSubstitutesInInclude()
+        {
+            var hocon = @"a {
+  b { 
+       include ""foo""
+  }";
+            var includeHocon = @"
+x = 123
+y = ${x}
+";
+            Func<string, HoconRoot> include = s => Parser.Parse(includeHocon, null);
+            var config = ConfigurationFactory.ParseString(hocon, include);
+
+            Assert.Equal(123, config.GetInt("a.b.x"));
+            Assert.Equal(123, config.GetInt("a.b.y"));
+        }
+
+        [Fact]
+        public void CanResolveSubstitutesInNestedIncludes()
+        {
+            var hocon = @"a.b.c {
+  d { 
+       include ""foo""
+  }";
+            var includeHocon = @"
+f = 123
+e {
+      include ""foo""
+}
+";
+
+            var includeHocon2 = @"
+x = 123
+y = ${x}
+";
+
+            HoconRoot Include2(string s) => Parser.Parse(includeHocon2, null);
+            HoconRoot Include(string s) => Parser.Parse(includeHocon, Include2);
+            var config = ConfigurationFactory.ParseString(hocon, Include);
+
+            Assert.Equal(123, config.GetInt("a.b.c.d.e.x"));
+            Assert.Equal(123, config.GetInt("a.b.c.d.e.y"));
+        }
+
+        /*
+         * FACT:
+         * If a key has been specified more than once, 
+         * the substitution will always evaluate to its latest-assigned value 
+         * (that is, it will evaluate to the merged object, or the last non-object value that was set, 
+         * in the entire document being parsed including all included files).
+         */
+        // TODO: Need test implementation.
+
+        /*
+         * FACT:
+         * If a configuration sets a value to null then it should not be looked up in the external source.
+         */
+        [Fact]
+        public void NullValueSubstitutionShouldNotLookUpExternalSource()
+        {
+            var hocon = @"
+MY_ENV_VAR = null
+a {
+  b = ${MY_ENV_VAR}
+}";
+            var value = "Environment_Var";
+            Environment.SetEnvironmentVariable("MY_ENV_VAR", value);
+            try
+            {
+                Assert.Null(ConfigurationFactory.ParseString(hocon).GetString("a.b"));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("MY_ENV_VAR", null);
+            }
+        }
+
+        [Fact]
+        public void NullValueQuestionMarkSubstitutionShouldNotLookUpExternalSource()
+        {
+            var hocon = @"
+MY_ENV_VAR = null
+a {
+  b = ""old value""
+  b = ${?MY_ENV_VAR}
+}";
+            var value = "Environment_Var";
+            Environment.SetEnvironmentVariable("MY_ENV_VAR", value);
+            try
+            {
+                Assert.Equal("old value", ConfigurationFactory.ParseString(hocon).GetString("a.b"));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("MY_ENV_VAR", null);
+            }
+        }
+
+        /*
+         * FACT:
+         * If a substitution does not match any value present in the configuration 
+         * and is not resolved by an external source, then it is undefined. 
+         * An undefined substitution with the ${foo} syntax is invalid and should generate an error.
+         */
+        [Fact]
+        public void ThrowsWhenSubstituteIsUndefined()
+        {
+            var hocon = @"a{
+    b = ${foo}
+}";
+            Assert.Throws<HoconParserException>(() => ConfigurationFactory.ParseString(hocon));
+        }
+
+        /*
+         * FACT:
+         * If a substitution with the ${?foo} syntax is undefined:
+         * If it is the value of an object field then the field should not be created.
+         */
+        [Fact]
+        public void UndefinedQuestionMarkSubstitutionShouldNotCreateField()
+        {
+            var hocon = @"a{
+    b = 1
+    c = ${?foo}
+}";
+            var config = ConfigurationFactory.ParseString(hocon);
+            Assert.False(config.HasPath("a.c"));
+        }
+
+        [Fact]
+        public void UndefinedQuestionMarkShouldFailSilently()
+        {
+            var hocon = @"a {
+  b = ${?a.c}
+}";
+            ConfigurationFactory.ParseString(hocon);
+        }
+
+        /*
+         * FACT:
+         * If a substitution with the ${?foo} syntax is undefined:
+         * If the field would have overridden a previously-set value for the same field, 
+         * then the previous value remains.
+         */
+        [Fact]
+        public void UndefinedQuestionMarkSubstitutionShouldNotChangeFieldValue()
+        {
+            var hocon = @"a{
+    b = 2
+    b = ${?foo}
+}";
+            var config = ConfigurationFactory.ParseString(hocon);
+            Assert.Equal(2, config.GetInt("a.b"));
+        }
+
+        /*
+         * FACT:
+         * If a substitution with the ${?foo} syntax is undefined:
+         * If it is an array element then the element should not be added.
+         */
+        [Fact]
+        public void UndefinedQuestionMarkSubstitutionShouldNotAddArrayElement()
+        {
+            var hocon = @"a{
+    b = [ 1, ${?foo}, 3, 4 ]
+}";
+            var config = ConfigurationFactory.ParseString(hocon);
+            Assert.True(new []{1, 3, 4}.SequenceEqual(config.GetIntList("a.b")));
+        }
+
+        /*
+         * FACT:
+         * If a substitution with the ${?foo} syntax is undefined:
+         * if it is part of a value concatenation with another string then it should become an empty string
+         */
+        [Fact]
+        public void UndefinedQuestionMarkSubstitutionShouldResolveToEmptyString()
+        {
+            var hocon = @"a{
+    b = My name is ${?foo}
+}";
+            var config = ConfigurationFactory.ParseString(hocon);
+            Assert.Equal("My name is ", config.GetString("a.b"));
+        }
+
+        /*
+         * FACT:
+         * If a substitution with the ${?foo} syntax is undefined:
+         * if part of a value concatenation with an object or array it should become an empty object or array.
+         */
+        [Fact]
+        public void UndefinedQuestionMarkSubstitutionShouldResolveToEmptyArray()
+        {
+            var hocon = @"a {
+  c = ${?a.b} [4,5,6]
+}";
+            Assert.True(new[] { 4, 5, 6 }.SequenceEqual(ConfigurationFactory.ParseString(hocon).GetIntList("a.c")));
+        }
+
+        [Fact]
+        public void UndefinedQuestionMarkSubstitutionShouldResolveToEmptyObject()
+        {
+            var hocon = @"
+foo : { a : 42 },
+foo : ${?foo}
+";
+
+            var config = ConfigurationFactory.ParseString(hocon);
+            Assert.NotNull(config.GetConfig("foo"));
+            Assert.Equal(42, config.GetInt("foo.a"));
+        }
+
+        /*
+         * FACT:
+         * foo : ${?bar} would avoid creating field foo if bar is undefined.
+         * foo : ${?bar}${?baz} would also avoid creating the field if both bar and baz are undefined.
+         */
+        [Fact]
+        public void UndefinedQuestionMarkSubstitutionAndResolvedQuestionMarkSubstitutionShouldResolveToTheResolvedSubtitude()
+        {
+            var hocon = @"
+bar : { a : 42 },
+foo : ${?bar}${?baz}
+";
+
+            var config = ConfigurationFactory.ParseString(hocon);
+            Assert.NotNull(config.GetConfig("foo"));
+            Assert.Equal(42, config.GetInt("foo.a"));
+        }
+
+        [Fact]
+        public void TwoUndefinedQuestionMarkSubstitutionShouldNotCreateField()
+        {
+            var hocon = @"a{
+    b = 1
+    foo = ${?bar}${?baz}
+}";
+            var config = ConfigurationFactory.ParseString(hocon);
+            Assert.False(config.HasPath("a.foo"));
+        }
+
+        /*
+         * Substitutions are not allowed in keys or nested inside other substitutions (path expressions)
+         */
+        [Fact]
+        public void ThrowsOnSubstitutionInKeys()
+        {
+            var hocon = @"a{
+    b = 1
+    c = b
+    ${a.c} = 2;
+}";
+            Assert.Throws<HoconParserException>(() => ConfigurationFactory.ParseString(hocon));
+        }
+
+        [Fact]
+        public void ThrowsOnSubstitutionWithQuestionMarkInKeys()
+        {
+            var hocon = @"a{
+    b = 1
+    c = b
+    ${?a.c} = 2;
+}";
+            Assert.Throws<HoconParserException>(() => ConfigurationFactory.ParseString(hocon));
+        }
+
+        [Fact]
+        public void ThrowsOnSubstitutionInSubstitution()
+        {
+            var hocon = @"a{
+    bar = foo
+    foo = ${?a.${?bar}}
+}";
+            Assert.Throws<HoconParserException>(() => ConfigurationFactory.ParseString(hocon));
+        }
+
+        /*
+         * FACT:
+         * A substitution is replaced with any value type (number, object, string, array, true, false, null)
+         */
+
+        [Fact]
+        public void CanAssignSubstitutionToField()
+        {
+            var hocon = @"a{
+    int = 1
+    number = 10.0
+    string = string
+    boolean = true
+    null = null
+
+    b = ${a.number}
+    c = ${a.string}
+    d = ${a.boolean}
+    e = ${a.null}
+    f = ${a.int}
+}";
+            var config = ConfigurationFactory.ParseString(hocon);
+            Assert.Equal(10.0, config.GetFloat("a.b"));
+            Assert.Equal("string", config.GetString("a.c"));
+            Assert.True(config.GetBoolean("a.d"));
+            Assert.Null(config.GetString("a.e"));
+            Assert.Equal(1, ConfigurationFactory.ParseString(hocon).GetInt("a.f"));
+        }
+
+        [Fact]
+        public void CanCSubstituteObject()
+        {
+            var hocon = @"a {
+  b {
+      foo = hello
+      bar = 123
+  }
+  c {
+     d = xyz
+     e = ${a.b}
+  }  
+}";
+            var ace = ConfigurationFactory.ParseString(hocon).GetConfig("a.c.e");
+            Assert.Equal("hello", ace.GetString("foo"));
+            Assert.Equal(123, ace.GetInt("bar"));
+        }
+
+        [Fact]
+        public void CanConcatenateArray()
+        {
+            var hocon = @"a {
+  b = [1,2,3]
+  c = ${a.b} [4,5,6]
+}";
+            Assert.True(new[] { 1, 2, 3, 4, 5, 6 }.SequenceEqual(ConfigurationFactory.ParseString(hocon).GetIntList("a.c")));
+        }
+
+        /*
+         * FACT:
+         * If the substitution is the only part of a value, then the type is preserved. Otherwise, it is value-concatenated to form a string.
+         */
+        [Fact]
+        public void FieldSubstitutionShouldPreserveType()
+        {
+            var hocon = @"a{
+    b = 1
+    c = ${a.b}23
+}";
+            var config = ConfigurationFactory.ParseString(hocon);
+            Assert.Equal(1, ConfigurationFactory.ParseString(hocon).GetInt("a.b"));
+            Assert.Equal(123, ConfigurationFactory.ParseString(hocon).GetInt("a.c"));
+        }
+
+        [Fact]
+        public void FieldSubstitutionWithDifferentTypesShouldConcatenateToString()
+        {
+            var hocon = @"a{
+    b = 1
+    c = ${a.b}foo
+}";
+            var config = ConfigurationFactory.ParseString(hocon);
+            Assert.Equal(1, ConfigurationFactory.ParseString(hocon).GetInt("a.b"));
+            Assert.Equal("1foo", ConfigurationFactory.ParseString(hocon).GetString("a.c"));
+        }
     }
 }

--- a/src/HOCON.Tests/UnquotedString.cs
+++ b/src/HOCON.Tests/UnquotedString.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Hocon.Tests
+{
+    public class UnquotedString
+    {
+
+    }
+}

--- a/src/HOCON.Tests/UnquotedString.cs
+++ b/src/HOCON.Tests/UnquotedString.cs
@@ -9,22 +9,45 @@ namespace Hocon.Tests
 {
     public class UnquotedString
     {
+        /*
+         * From: String value concatenation.
+         */
+
+        /*
+         * FACT:
+         * Whitespace before the first and after the last simple value must be discarded
+         */
         [Fact]
         public void ShouldRemoveAllLeadingWhitespace()
         {
-            var hocon = $"a = {Whitespace.Whitespaces}literal";
+            var hocon = $"a = {Whitespace.Whitespaces}literal value";
             var config = ConfigurationFactory.ParseString(hocon);
 
-            Assert.Equal("literal", config.GetString("a"));
+            Assert.Equal("literal value", config.GetString("a"));
         }
 
         [Fact]
         public void ShouldRemoveAllTrailingWhitespace()
         {
-            var hocon = $"a = literal{Whitespace.Whitespaces}";
+            var hocon = $"a = literal value{Whitespace.Whitespaces}";
             var config = ConfigurationFactory.ParseString(hocon);
 
-            Assert.Equal("literal", config.GetString("a"));
+            Assert.Equal("literal value", config.GetString("a"));
+        }
+
+        /*
+         * FACT:
+         * As long as simple values are separated only by non-newline whitespace, 
+         * the whitespace between them is preserved and the values, along with the whitespace, 
+         * are concatenated into a string.
+         */
+        [Fact]
+        public void ShouldPreserveWhitespacesInTheMiddle()
+        {
+            var hocon = $"a = literal{Whitespace.Whitespaces}value";
+            var config = ConfigurationFactory.ParseString(hocon);
+
+            Assert.Equal($"literal{Whitespace.Whitespaces}value", config.GetString("a"));
         }
     }
 }

--- a/src/HOCON.Tests/UnquotedString.cs
+++ b/src/HOCON.Tests/UnquotedString.cs
@@ -3,11 +3,28 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Xunit;
 
 namespace Hocon.Tests
 {
     public class UnquotedString
     {
+        [Fact]
+        public void ShouldRemoveAllLeadingWhitespace()
+        {
+            var hocon = $"a = {Whitespace.Whitespaces}literal";
+            var config = ConfigurationFactory.ParseString(hocon);
 
+            Assert.Equal("literal", config.GetString("a"));
+        }
+
+        [Fact]
+        public void ShouldRemoveAllTrailingWhitespace()
+        {
+            var hocon = $"a = literal{Whitespace.Whitespaces}";
+            var config = ConfigurationFactory.ParseString(hocon);
+
+            Assert.Equal("literal", config.GetString("a"));
+        }
     }
 }

--- a/src/HOCON.Tests/Whitespace.cs
+++ b/src/HOCON.Tests/Whitespace.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Hocon.Tests
+{
+    public class Whitespace
+    {
+        // These are all the characters defined as whitespace by Hocon spec 
+        // Unicode space separator (Zs category)
+        private const char Space = '\u0020';
+        private const char NoBreakSpace = '\u00A0';
+        private const char OghamSpaceMark = '\u1680';
+        private const char EnQuad = '\u2000';
+        private const char EmQuad = '\u2001';
+        private const char EnSpace = '\u2002';
+        private const char EmSpace = '\u2003';
+        private const char ThreePerEmSpace = '\u2004';
+        private const char FourPerEmSpace = '\u2005';
+        private const char SixPerEmSpace = '\u2006';
+        private const char FigureSpace = '\u2007';
+        private const char PunctuationSpace = '\u2008';
+        private const char ThinSpace = '\u2009';
+        private const char HairSpace = '\u200A';
+        private const char NarrowNoBreakSpace = '\u202F';
+        private const char MediumMathematicalSpace = '\u205F';
+        private const char IdeographicSpace = '\u3000';
+
+        // Unicode line separator(Zl category)
+        private const char LineSeparator = '\u2028';
+
+        // Unicode paragraph separator (Zp category)
+        private const char ParagraphSeparator = '\u2029';
+
+        // Unicode BOM
+        private const char BOM = '\uFEFF';
+
+        // Other Unicode whitespaces
+        private const char Tab = '\u0009';              // \t
+        private const char NewLine = '\u000A';          // \n
+        private const char VerticalTab = '\u000B';      // \v
+        private const char FormFeed = '\u000C';         // \f
+        private const char CarriageReturn = '\u000D';   // \r
+        private const char FileSeparator = '\u001C';
+        private const char GroupSeparator = '\u001D';
+        private const char RecordSeparator = '\u001E';
+        private const char UnitSeparator = '\u001F';
+
+        private readonly string Whitespaces = new string(new [] {
+            Space, NoBreakSpace, OghamSpaceMark, EnQuad, EmQuad,
+            EnSpace, EmSpace, ThreePerEmSpace, FourPerEmSpace, SixPerEmSpace,
+            FigureSpace, PunctuationSpace, ThinSpace, HairSpace, NarrowNoBreakSpace,
+            MediumMathematicalSpace, IdeographicSpace,
+
+            // Unicode line separator(Zl category)
+            LineSeparator,
+
+            // Unicode paragraph separator (Zp category)
+            ParagraphSeparator,
+
+            // Unicode BOM
+            BOM,
+
+            // Other Unicode whitespaces
+            Tab, VerticalTab, FormFeed, CarriageReturn,
+            FileSeparator, GroupSeparator, RecordSeparator, UnitSeparator,
+        });
+
+        // TODO: Figure out what needs to be tested for whitespaces, probably string.Trim() for unquoted strings
+    }
+}

--- a/src/HOCON.Tests/Whitespace.cs
+++ b/src/HOCON.Tests/Whitespace.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Xunit;
 
 namespace Hocon.Tests
 {
@@ -10,45 +11,45 @@ namespace Hocon.Tests
     {
         // These are all the characters defined as whitespace by Hocon spec 
         // Unicode space separator (Zs category)
-        private const char Space = '\u0020';
-        private const char NoBreakSpace = '\u00A0';
-        private const char OghamSpaceMark = '\u1680';
-        private const char EnQuad = '\u2000';
-        private const char EmQuad = '\u2001';
-        private const char EnSpace = '\u2002';
-        private const char EmSpace = '\u2003';
-        private const char ThreePerEmSpace = '\u2004';
-        private const char FourPerEmSpace = '\u2005';
-        private const char SixPerEmSpace = '\u2006';
-        private const char FigureSpace = '\u2007';
-        private const char PunctuationSpace = '\u2008';
-        private const char ThinSpace = '\u2009';
-        private const char HairSpace = '\u200A';
-        private const char NarrowNoBreakSpace = '\u202F';
-        private const char MediumMathematicalSpace = '\u205F';
-        private const char IdeographicSpace = '\u3000';
+        public static readonly char Space = '\u0020';
+        public static readonly char NoBreakSpace = '\u00A0';
+        public static readonly char OghamSpaceMark = '\u1680';
+        public static readonly char EnQuad = '\u2000';
+        public static readonly char EmQuad = '\u2001';
+        public static readonly char EnSpace = '\u2002';
+        public static readonly char EmSpace = '\u2003';
+        public static readonly char ThreePerEmSpace = '\u2004';
+        public static readonly char FourPerEmSpace = '\u2005';
+        public static readonly char SixPerEmSpace = '\u2006';
+        public static readonly char FigureSpace = '\u2007';
+        public static readonly char PunctuationSpace = '\u2008';
+        public static readonly char ThinSpace = '\u2009';
+        public static readonly char HairSpace = '\u200A';
+        public static readonly char NarrowNoBreakSpace = '\u202F';
+        public static readonly char MediumMathematicalSpace = '\u205F';
+        public static readonly char IdeographicSpace = '\u3000';
 
         // Unicode line separator(Zl category)
-        private const char LineSeparator = '\u2028';
+        public static readonly char LineSeparator = '\u2028';
 
         // Unicode paragraph separator (Zp category)
-        private const char ParagraphSeparator = '\u2029';
+        public static readonly char ParagraphSeparator = '\u2029';
 
         // Unicode BOM
-        private const char BOM = '\uFEFF';
+        public static readonly char BOM = '\uFEFF';
 
         // Other Unicode whitespaces
-        private const char Tab = '\u0009';              // \t
-        private const char NewLine = '\u000A';          // \n
-        private const char VerticalTab = '\u000B';      // \v
-        private const char FormFeed = '\u000C';         // \f
-        private const char CarriageReturn = '\u000D';   // \r
-        private const char FileSeparator = '\u001C';
-        private const char GroupSeparator = '\u001D';
-        private const char RecordSeparator = '\u001E';
-        private const char UnitSeparator = '\u001F';
+        public static readonly char Tab = '\u0009';              // \t
+        public static readonly char NewLine = '\u000A';          // \n
+        public static readonly char VerticalTab = '\u000B';      // \v
+        public static readonly char FormFeed = '\u000C';         // \f
+        public static readonly char CarriageReturn = '\u000D';   // \r
+        public static readonly char FileSeparator = '\u001C';
+        public static readonly char GroupSeparator = '\u001D';
+        public static readonly char RecordSeparator = '\u001E';
+        public static readonly char UnitSeparator = '\u001F';
 
-        private readonly string Whitespaces = new string(new [] {
+        public static readonly string Whitespaces = new string(new [] {
             Space, NoBreakSpace, OghamSpaceMark, EnQuad, EmQuad,
             EnSpace, EmSpace, ThreePerEmSpace, FourPerEmSpace, SixPerEmSpace,
             FigureSpace, PunctuationSpace, ThinSpace, HairSpace, NarrowNoBreakSpace,


### PR DESCRIPTION
- [x] Comments
- [x] Omit root braces
- [x] Key-value separator
- [x] Commas
- [x] Duplicate keys and object merging
- [X ] Unquoted strings
- [x] Substitutions - Normal