### PR TITLE
removed Hocon.Benchmarks nuget package

### DIFF
--- a/src/Hocon.Benchmarks/Hocon.Benchmarks.csproj
+++ b/src/Hocon.Benchmarks/Hocon.Benchmarks.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/common.props
+++ b/src/common.props
@@ -2,8 +2,9 @@
   <PropertyGroup>
     <Copyright>Copyright © 2014-2018 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>0.2.0-Prerelease</VersionPrefix>
-    <PackageReleaseNotes>.NET Standard 1.3 and .NET 4.5 dual support for core HOCON library.
+    <VersionPrefix>0.1.0</VersionPrefix>
+    <PackageReleaseNotes>.NET Standard 1.2 and .NET 4.5 dual support for core HOCON library.
+Dropped dependency on JSON.NET.
 Separated HOCON from Akka conceptually and in terms of namespaces.</PackageReleaseNotes>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/HOCON</PackageProjectUrl>


### PR DESCRIPTION
Just needed to add the `<IsPackable>false</IsPackable>` to stop NuGet packages from being released for the HOCON benchmarks