### PR TITLE
fixed bug where dot notation doesn't work properly

### DIFF
--- a/src/HOCON.Tests/DuplicateKeysAndObjectMerging.cs
+++ b/src/HOCON.Tests/DuplicateKeysAndObjectMerging.cs
@@ -123,5 +123,21 @@ foo
             Assert.Equal(43, config.GetInt("foo.b"));
         }
 
+        /// <summary>
+        /// The `a.b.c` dot syntax may be used to add new fields or override old fields of a HOCON object.
+        /// </summary>
+        [Fact]
+        public void ObjectCanMixBraceAndDotSyntax()
+        {
+            var hocon = @"
+    foo { x = 1 }
+    foo { y = 2 }
+    foo.z = 32
+";
+            var config = Parser.Parse(hocon);
+            Assert.Equal(1, config.GetInt("foo.x"));
+            Assert.Equal(2, config.GetInt("foo.y"));
+            Assert.Equal(32, config.GetInt("foo.z"));
+        }
     }
 }

--- a/src/HOCON.Tests/PathTests.cs
+++ b/src/HOCON.Tests/PathTests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Hocon.Tests
+{
+    public class PathTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public PathTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void PathToStringAddQuotesIfRequired()
+        {
+            var path1 = new HoconPath(new string[] {
+                "i am",
+                "kong.fu",
+                "panda"
+            });
+
+            var path2 = new HoconPath(new string[]
+            {
+                "i am",
+                "kong",
+                "fu",
+                "panda"
+            });
+
+            // path1 => "i am"."kong.fu".panda 
+            // path2 => "i am".kong.fu.panda
+            Assert.NotEqual(path1.Value, path2.Value);
+            Assert.Equal("\"i am\".\"kong.fu\".panda", path1.Value);
+        }
+
+        [Fact]
+        public void PathToStringEscapeQuotesInKey()
+        {
+            var path = new HoconPath(new string[]
+            {
+                "please",
+                "es\"cape",
+                "me"
+            });
+
+            // please."es\"cape".me
+            Assert.Equal("please.\"es\\\"cape\".me", path.Value);
+        }
+    }
+}

--- a/src/HOCON.Tests/PathTests.cs
+++ b/src/HOCON.Tests/PathTests.cs
@@ -17,8 +17,41 @@ namespace Hocon.Tests
             _output = output;
         }
 
+        [Theory]
+        [InlineData(new string[] { "foo", "bar" }, "foo.bar")]
+        [InlineData(new string[] { "foo", "bar.baz" }, "foo.\"bar.baz\"")]
+        [InlineData(new string[] { "shoot", "a \"laser\" beam" }, "shoot.\"a \\\"laser\\\" beam\"")]
+        [InlineData(new string[] { "foo", "bar\nbaz" }, "foo.\"bar\\nbaz\"")]
+        [InlineData(new string[] { "foo", "bar baz", " wis " }, "foo.bar baz. wis ")]
+        [InlineData(new string[] { "foo", "bar\tbaz"}, "foo.bar\tbaz")]
+        [InlineData(new string[] { "foo", "bar\r\nbaz", "x\r" }, "foo.\"bar\r\\nbaz\".x\r")]
+        [InlineData(new string[] { "foo", "" }, "foo.\"\"")]
+        [InlineData(new string[] { "foo", "\\" }, "foo.\"\\\\\"")]
+        [InlineData(new string[] { "$\"{}[]:=,#`^?!@*&\\" }, "\"" + "$\\\"{}[]:=,#`^?!@*&\\\\" + "\"")]
+        public void CanParseAndSerialize(string[] pathKeys, string path)
+        {
+            HoconPath hoconPath = new HoconPath(pathKeys);
+            HoconPath hoconPath2 = HoconPath.Parse(path);
+
+            Assert.Equal(path, hoconPath.Value);
+            Assert.Equal(path, hoconPath2.Value);
+
+            Assert.Equal(hoconPath, hoconPath2);
+
+            Assert.Equal(pathKeys.Length, hoconPath.Count);
+            Assert.Equal(pathKeys.Length, hoconPath2.Count);
+
+            for (int i = 0; i < pathKeys.Length; i++)
+            {
+                Assert.Equal(pathKeys[i], hoconPath[i]);
+                Assert.Equal(pathKeys[i], hoconPath2[i]);
+            }
+
+            _output.WriteLine(string.Format("Path [{0}] serialized from: {1}", path, string.Join(", ", pathKeys)));
+        }
+
         [Fact]
-        public void PathToStringAddQuotesIfRequired()
+        public void PathToStringQuoteKeysContainingDot()
         {
             var path1 = new HoconPath(new string[] {
                 "i am",
@@ -34,24 +67,10 @@ namespace Hocon.Tests
                 "panda"
             });
 
-            // path1 => "i am"."kong.fu".panda 
-            // path2 => "i am".kong.fu.panda
+            // path1 => i am."kong.fu".panda 
+            // path2 => i am.kong.fu.panda
             Assert.NotEqual(path1.Value, path2.Value);
-            Assert.Equal("\"i am\".\"kong.fu\".panda", path1.Value);
-        }
-
-        [Fact]
-        public void PathToStringEscapeQuotesInKey()
-        {
-            var path = new HoconPath(new string[]
-            {
-                "please",
-                "es\"cape",
-                "me"
-            });
-
-            // please."es\"cape".me
-            Assert.Equal("please.\"es\\\"cape\".me", path.Value);
+            Assert.Equal("i am.\"kong.fu\".panda", path1.Value);
         }
     }
 }

--- a/src/HOCON/Impl/HoconObject.cs
+++ b/src/HOCON/Impl/HoconObject.cs
@@ -284,7 +284,10 @@ namespace Hocon
                     return result;
 
                 child.EnsureFieldIsObject();
-                currentObject = child.GetObject();
+
+                // cannot use child.GetObject() because it would return a new merged object instance, which 
+                // breaks autoref with the parent object in the previous loop
+                currentObject = child.Value.GetObject();
             }
         }
 

--- a/src/HOCON/Impl/HoconPath.cs
+++ b/src/HOCON/Impl/HoconPath.cs
@@ -16,7 +16,30 @@ namespace Hocon
     public sealed class HoconPath:List<string>, IEquatable<HoconPath>
     {
         public bool IsEmpty => Count == 0;
-        public string Value => string.Join(".", this);
+
+        public string Value
+        {
+            get
+            {
+                if (IsEmpty)
+                    return string.Empty;
+
+                List<string> pathSegments = new List<string>();
+                foreach (string subPath in this)
+                {
+                    // #todo escape newline chars in path?
+                    if (subPath.NeedTripleQuotes())
+                        throw new HoconException("Unable to convert the path to string because a sub path contains newline character.");
+
+                    pathSegments.Add(subPath.Contains('.') || subPath.ContainsHoconWhitespaceExceptNewLine()
+                        ? subPath.AddQuotes()
+                        : subPath.AddQuotesIfRequired());
+                }
+
+                return string.Join(".", pathSegments);
+            }
+        }
+
         public string Key => this[Count - 1];
 
         public HoconPath() { }

--- a/src/HOCON/Impl/Utils.cs
+++ b/src/HOCON/Impl/Utils.cs
@@ -114,7 +114,7 @@ namespace Hocon
             => Hexadecimal.Contains(c);
 
         public static string ToHoconSafe(this string s)
-            => s.NeedTripleQuotes() ? $"\"\"\"{s}\"\"\"" : s.NeedQuotes() ? $"\"{s}\"" : s;
+            => s.NeedTripleQuotes() ? $"\"\"\"{s}\"\"\"" : s.NeedQuotes() ? s.AddQuotes() : s;
 
         public static HoconPath ToHoconPath(this string path)
             => HoconPath.Parse(path);
@@ -122,17 +122,6 @@ namespace Hocon
         public static bool Contains(this string s, char c)
         {
             return s.IndexOf(c) != -1;
-        }
-
-        public static bool ContainsHoconWhitespaceExceptNewLine(this string s)
-        {
-            foreach (char c in s)
-            {
-                if (c.IsWhitespaceWithNoNewLine())
-                    return true;
-            }
-
-            return false;
         }
 
         #endregion
@@ -192,13 +181,6 @@ namespace Hocon
 
         public static bool NeedTripleQuotes(this string s)
             => s.NeedQuotes() && s.Contains(Utils.NewLine);
-
-        public static string AddQuotesIfRequired(this string s)
-        {
-            return s.NeedTripleQuotes() ? ("\"\"\"" + s + "\"\"\"")
-                : s.NeedQuotes() ? AddQuotes(s)
-                : s;
-        }
 
         public static string AddQuotes(this string s)
         {

--- a/src/HOCON/Impl/Utils.cs
+++ b/src/HOCON/Impl/Utils.cs
@@ -124,6 +124,17 @@ namespace Hocon
             return s.IndexOf(c) != -1;
         }
 
+        public static bool ContainsHoconWhitespaceExceptNewLine(this string s)
+        {
+            foreach (char c in s)
+            {
+                if (c.IsWhitespaceWithNoNewLine())
+                    return true;
+            }
+
+            return false;
+        }
+
         #endregion
 
         #region Token extensions
@@ -182,5 +193,19 @@ namespace Hocon
         public static bool NeedTripleQuotes(this string s)
             => s.NeedQuotes() && s.Contains(Utils.NewLine);
 
+        public static string AddQuotesIfRequired(this string s)
+        {
+            return s.NeedTripleQuotes() ? ("\"\"\"" + s + "\"\"\"")
+                : s.NeedQuotes() ? AddQuotes(s)
+                : s;
+        }
+
+        public static string AddQuotes(this string s)
+        {
+            if (s.Contains('"'))
+                return "\"" + s.Replace("\"", "\\\"") + "\"";
+
+            return "\"" + s + "\"";
+        }
     }
 }


### PR DESCRIPTION
This is an attempt at addressing issue #71 
The bug is caused by attempting to add a new key to a merged object, which is not the same as the field's actual underlying value.