### PR TITLE
added 1.1.0 HOCON release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,12 @@
+#### 1.1.0 July 10 2019 ####
+HOCON 1.1.0 contains a large number of bug fixes and improvements over HOCON 1.0.0, including:
+
+* [Fix: fully qualified type name with assembly cant be used as property name ](https://github.com/akkadotnet/HOCON/issues/79)
+* [Fix: unable to use include keyword at root level](https://github.com/akkadotnet/HOCON/pull/69)
+* [Fix. Child field path was not concatenated with its parent path](https://github.com/akkadotnet/HOCON/pull/96)
+* [Fix: bug when getting a string with a substitution as an array element](https://github.com/akkadotnet/HOCON/pull/88)
+* [Fix: Object fields containing objects may not return proper object value in certain circumstances. ](https://github.com/akkadotnet/HOCON/pull/93)
+
 #### 1.0.0 November 14th 2018 ####
 HOCON 1.0.0 is a complete and total rewrite of the HOCON parsing engine, designed to work with both the .NET Framework (4.5 and later) and .NET Standard 1.3.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-#### 1.1.0 July 10 2019 ####
+#### 1.1.0 July 29 2019 ####
 HOCON 1.1.0 contains a large number of bug fixes and improvements over HOCON 1.0.0, including:
 
 * [Fix: fully qualified type name with assembly cant be used as property name ](https://github.com/akkadotnet/HOCON/issues/79)
@@ -6,6 +6,8 @@ HOCON 1.1.0 contains a large number of bug fixes and improvements over HOCON 1.0
 * [Fix. Child field path was not concatenated with its parent path](https://github.com/akkadotnet/HOCON/pull/96)
 * [Fix: bug when getting a string with a substitution as an array element](https://github.com/akkadotnet/HOCON/pull/88)
 * [Fix: Object fields containing objects may not return proper object value in certain circumstances. ](https://github.com/akkadotnet/HOCON/pull/93)
+* [Fix: Improper value instantiation and parenting during parsing caused a disconnected tree nodes.](https://github.com/akkadotnet/HOCON/pull/99)
+* [Fix: HoconValue.Undefined is inconsistent](https://github.com/akkadotnet/HOCON/pull/101)
 
 #### 1.0.0 November 14th 2018 ####
 HOCON 1.0.0 is a complete and total rewrite of the HOCON parsing engine, designed to work with both the .NET Framework (4.5 and later) and .NET Standard 1.3.

--- a/src/common.props
+++ b/src/common.props
@@ -2,18 +2,13 @@
   <PropertyGroup>
     <Copyright>Copyright © 2014-2018 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.0.0</VersionPrefix>
-    <PackageReleaseNotes>HOCON 1.0.0 is a complete and total rewrite of the HOCON parsing engine, designed to work with both the .NET Framework (4.5 and later) and .NET Standard 1.3.
-The performance has significantly improved, as have the range of features supported by this library, including:
-Built-in enviroment variable substitution;
-[Support for better byte and time formats](https://github.com/akkadotnet/akka.net/pull/3600);
-[Improved object substitution and merging](https://github.com/akkadotnet/HOCON/pull/55);
-and many more features.
-This library will be developed and released independently from Akka.NET itself, but beginning with Akka.NET v1.4 it will be taken as a dependency by the core Akka libraries.
-HOCON ships as two NuGet packages:
-`Hocon` - includes all core parser, substitution, tokenization, and other functionality;
-`Hocon.Configuration` - adds `App.config` and `System.Configuration` integration to HOCON.
-`Hocon.Extensions.Configuration` - adds HOCON support for the popular `Microsoft.Extensions.Configuration` library used in ASP.NET Core and other parts of the new .NET Core runtime.</PackageReleaseNotes>
+    <VersionPrefix>1.1.0</VersionPrefix>
+    <PackageReleaseNotes>HOCON 1.1.0 contains a large number of bug fixes and improvements over HOCON 1.0.0, including:
+[Fix: fully qualified type name with assembly cant be used as property name ](https://github.com/akkadotnet/HOCON/issues/79)
+[Fix: unable to use include keyword at root level](https://github.com/akkadotnet/HOCON/pull/69)
+[Fix. Child field path was not concatenated with its parent path](https://github.com/akkadotnet/HOCON/pull/96)
+[Fix: bug when getting a string with a substitution as an array element](https://github.com/akkadotnet/HOCON/pull/88)
+[Fix: Object fields containing objects may not return proper object value in certain circumstances. ](https://github.com/akkadotnet/HOCON/pull/93)</PackageReleaseNotes>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/HOCON</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/HOCON/blob/master/LICENSE</PackageLicenseUrl>

--- a/src/common.props
+++ b/src/common.props
@@ -8,7 +8,9 @@
 [Fix: unable to use include keyword at root level](https://github.com/akkadotnet/HOCON/pull/69)
 [Fix. Child field path was not concatenated with its parent path](https://github.com/akkadotnet/HOCON/pull/96)
 [Fix: bug when getting a string with a substitution as an array element](https://github.com/akkadotnet/HOCON/pull/88)
-[Fix: Object fields containing objects may not return proper object value in certain circumstances. ](https://github.com/akkadotnet/HOCON/pull/93)</PackageReleaseNotes>
+[Fix: Object fields containing objects may not return proper object value in certain circumstances. ](https://github.com/akkadotnet/HOCON/pull/93)
+[Fix: Improper value instantiation and parenting during parsing caused a disconnected tree nodes.](https://github.com/akkadotnet/HOCON/pull/99)
+[Fix: HoconValue.Undefined is inconsistent](https://github.com/akkadotnet/HOCON/pull/101)</PackageReleaseNotes>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/HOCON</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/HOCON/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
#### 1.1.0 July 29 2019 ####
HOCON 1.1.0 contains a large number of bug fixes and improvements over HOCON 1.0.0, including:

* [Fix: fully qualified type name with assembly cant be used as property name ](https://github.com/akkadotnet/HOCON/issues/79)
* [Fix: unable to use include keyword at root level](https://github.com/akkadotnet/HOCON/pull/69)
* [Fix. Child field path was not concatenated with its parent path](https://github.com/akkadotnet/HOCON/pull/96)
* [Fix: bug when getting a string with a substitution as an array element](https://github.com/akkadotnet/HOCON/pull/88)
* [Fix: Object fields containing objects may not return proper object value in certain circumstances. ](https://github.com/akkadotnet/HOCON/pull/93)
* [Fix: Improper value instantiation and parenting during parsing caused a disconnected tree nodes.](https://github.com/akkadotnet/HOCON/pull/99)
* [Fix: HoconValue.Undefined is inconsistent](https://github.com/akkadotnet/HOCON/pull/101)