### PR TITLE
Improper value instantiation and parenting during parsing caused a disconnected tree nodes.

### DIFF
--- a/src/Hocon.Tests/SelfReferentialSubstitution.cs
+++ b/src/Hocon.Tests/SelfReferentialSubstitution.cs
@@ -58,8 +58,22 @@ path : ${path} [ /usr/bin ]";
   a.b: ${a.b} "":d""
 }")]
         [InlineData(@"{
+  a {
+    b: ""a:b:c""
+  }
+  a {
+    b: ${a.b} "":d""
+  }
+}")]
+        [InlineData(@"{
   a.b: ""a:b:c""
   a.b: ${a.b} "":d""
+}")]
+        [InlineData(@"{
+  a.b: ""a:b:c""
+  a {
+    b: ${a.b} "":d""
+  }
 }")]
         public void CanValueConcatenateOlderValueInsideObject_Issue_95(string hocon)
         {
@@ -75,8 +89,22 @@ path : ${path} [ /usr/bin ]";
   a.b: ${a.b} [3, 4]
 }")]
         [InlineData(@"{
+  a {
+    b: [1, 2]
+  }
+  a {
+    b: ${a.b} [3, 4]
+  }
+}")]
+        [InlineData(@"{
   a.b: [1, 2]
   a.b: ${a.b} [3, 4]
+}")]
+        [InlineData(@"{
+  a.b: [1, 2]
+  a {
+    b: ${a.b} [3, 4]
+  }
 }")]
         public void CanValueConcatenateOlderArrayInsideObject_Issue_95(string hocon)
         {
@@ -150,7 +178,8 @@ foo : { a : 1 }
 
         /*
          * FACT:
-         *  the optional substitution syntax ${?foo} does not create a cycle
+         * If a substitution is hidden by a value that could not be merged with it
+         * (by a non-object value) then it is never evaluated and no error will be reported
          */
         [Fact]
         public void HiddenSubstitutionShouldNeverBeEvaluated()

--- a/src/Hocon.Tests/SelfReferentialSubstitution.cs
+++ b/src/Hocon.Tests/SelfReferentialSubstitution.cs
@@ -75,7 +75,7 @@ path : ${path} [ /usr/bin ]";
     b: ${a.b} "":d""
   }
 }")]
-        public void CanValueConcatenateOlderValueInsideObject_Issue_95(string hocon)
+        public void CanValueConcatenateOlderValueInsideObject_Issue_95_97(string hocon)
         {
             var config = Parser.Parse(hocon);
             Assert.Equal("a:b:c:d", config.GetString("a.b"));
@@ -86,18 +86,14 @@ path : ${path} [ /usr/bin ]";
   a {
     b: [1, 2]
   }
-  a.b: ${a.b} [3, 4]
+  a {
+    b: ${a.b} [3, 4]
+  }
 }")]
         [InlineData(@"{
   a {
     b: [1, 2]
   }
-  a {
-    b: ${a.b} [3, 4]
-  }
-}")]
-        [InlineData(@"{
-  a.b: [1, 2]
   a.b: ${a.b} [3, 4]
 }")]
         [InlineData(@"{
@@ -106,7 +102,11 @@ path : ${path} [ /usr/bin ]";
     b: ${a.b} [3, 4]
   }
 }")]
-        public void CanValueConcatenateOlderArrayInsideObject_Issue_95(string hocon)
+        [InlineData(@"{
+  a.b: [1, 2]
+  a.b: ${a.b} [3, 4]
+}")]
+        public void CanValueConcatenateOlderArrayInsideObject_Issue_95_97(string hocon)
         {
             var config = Parser.Parse(hocon);
             Assert.True(new[] { 1, 2, 3, 4 }.SequenceEqual(config.GetIntList("a.b")));
@@ -212,7 +212,11 @@ b = [ 4, 5 ]
             HoconRoot config = null;
             var ex = Record.Exception(() => config = Parser.Parse(hocon));
             Assert.Null(ex);
-            Assert.True( new []{1, 2, 3, 4, 5}.SequenceEqual(config.GetIntList("a")) );
+            var array = config.GetValue("a").GetArray();
+            Assert.Equal(1, array[0].GetInt());
+            Assert.Equal(2, array[1].GetInt());
+            Assert.Equal(3, array[2].GetInt());
+            Assert.True( new []{4, 5}.SequenceEqual(array[3].GetIntList()) );
         }
 
         /*

--- a/src/Hocon/Impl/HoconArray.cs
+++ b/src/Hocon/Impl/HoconArray.cs
@@ -74,7 +74,7 @@ namespace Hocon
 
         internal void ResolveValue(HoconSubstitution sub)
         {
-            var subValue = (HoconValue) sub.Parent;
+            var subValue = (HoconValue)sub.Parent;
             if (sub.Type == HoconType.Empty)
             {
                 subValue.Remove(sub);
@@ -87,19 +87,6 @@ namespace Hocon
             {
                 throw HoconParserException.Create(sub, sub.Path,
                     $"Substitution value must match the rest of the field type or empty. Array value type: {_arrayType}, substitution type: {sub.Type}");
-            }
-
-            if (sub.ResolvedValue.Type == HoconType.Array)
-            {
-                var childIndex = IndexOf(subValue);
-                Remove(subValue);
-
-                var array = sub.ResolvedValue.GetArray();
-                foreach (var arrayValue in array)
-                {
-                    Insert(childIndex, (HoconValue) arrayValue.Clone(this));
-                    childIndex++;
-                }
             }
         }
 
@@ -120,7 +107,7 @@ namespace Hocon
             var newArray = new HoconArray(newParent);
             foreach (var value in this)
             {
-                newArray.Add((HoconValue)value.Clone(newArray));
+                newArray.Add(value);
             }
             return newArray;
         }

--- a/src/Hocon/Impl/HoconField.cs
+++ b/src/Hocon/Impl/HoconField.cs
@@ -25,7 +25,7 @@ namespace Hocon
 
     public sealed class HoconField:IHoconElement
     {
-        private readonly List<HoconValue> _internalValues;
+        private readonly List<HoconValue> _internalValues = new List<HoconValue>();
 
         /// <inheritdoc/>
         public IHoconElement Parent { get; }
@@ -38,17 +38,6 @@ namespace Hocon
 
         public HoconPath Path { get; }
         public string Key => Path.Key;
-
-        internal HoconField ParentField
-        {
-            get
-            {
-                var p = Parent;
-                while (p != null && !(p is HoconField))
-                    p = p.Parent;
-                return p as HoconField;
-            }
-        }
 
         /// <summary>
         /// Returns true if there are old values stored.
@@ -90,7 +79,6 @@ namespace Hocon
 
             Path = new HoconPath(parent.Path) {key};
             Parent = parent;
-            _internalValues = new List<HoconValue>();
         }
 
         internal void EnsureFieldIsObject()
@@ -116,6 +104,7 @@ namespace Hocon
                     }
                 }
             }
+
             _internalValues.Add(value);
         }
 
@@ -186,7 +175,7 @@ namespace Hocon
             var newField = new HoconField(Key, (HoconObject)newParent);
             foreach (var internalValue in _internalValues)
             {
-                newField._internalValues.Add((HoconValue)internalValue.Clone(newField));
+                newField._internalValues.Add(internalValue);
             }
             return newField;
         }

--- a/src/Hocon/Impl/HoconMergedObject.cs
+++ b/src/Hocon/Impl/HoconMergedObject.cs
@@ -20,40 +20,49 @@ namespace Hocon
         public HoconMergedObject(IHoconElement parent, List<HoconObject> objects) : base(parent)
         {
             Objects = objects;
-            foreach (var obj in objects)
+            foreach (var obj in Objects)
             {
-                foreach (var kvp in obj)
-                {
-                    base.SetField(kvp.Key, kvp.Value);
-                }
+                base.Merge(obj);
             }
+        }
+
+        internal override HoconField TraversePath(HoconPath relativePath)
+        {
+            var result = Objects.Last().TraversePath(relativePath);
+            Clear();
+            foreach (var obj in Objects)
+            {
+                base.Merge(obj);
+            }
+
+            return result;
+        }
+
+        internal override HoconField GetOrCreateKey(string key)
+        {
+            var result = Objects.Last().GetOrCreateKey(key);
+            Clear();
+            foreach (var obj in Objects)
+            {
+                base.Merge(obj);
+            }
+
+            return result;
         }
 
         internal override void SetField(string key, HoconField value)
         {
             Objects.Last().SetField(key, value);
-        }
-
-        private void SoftMerge(HoconObject other)
-        {
-            foreach (var kvp in other)
-            {
-                base.SetField(kvp.Key, kvp.Value);
-            }
+            base.SetField(key, value);
         }
 
         public override void Merge(HoconObject other)
         {
-            var value = new HoconValue(Parent);
-            value.Add(other.Clone(value));
-            ((HoconField)Parent).SetValue(value);
+            var parent = (HoconValue) Parent;
+            parent.Add(other);
 
-            //((HoconField)Parent).Value.Add(other.Clone(((HoconField)Parent).Value));
-            foreach (var kvp in other)
-            {
-                base.SetField(kvp.Key, kvp.Value);
-            }
-            //base.Merge(other);
+            Objects.Add(other);
+            base.Merge(other);
         }
         
     }

--- a/src/Hocon/Impl/HoconMergedObject.cs
+++ b/src/Hocon/Impl/HoconMergedObject.cs
@@ -28,8 +28,11 @@ namespace Hocon
 
         public override void Merge(HoconObject other)
         {
-            ((HoconField)Parent).Value.Add(other.Clone(((HoconField)Parent).Value));
+            var owner = Objects.Last();
+            owner.Merge(other);
+            //((HoconField)Parent).Value.Add(other.Clone(((HoconField)Parent).Value));
             base.Merge(other);
         }
+        
     }
 }

--- a/src/Hocon/Impl/HoconMergedObject.cs
+++ b/src/Hocon/Impl/HoconMergedObject.cs
@@ -22,16 +22,38 @@ namespace Hocon
             Objects = objects;
             foreach (var obj in objects)
             {
-                base.Merge(obj);
+                foreach (var kvp in obj)
+                {
+                    base.SetField(kvp.Key, kvp.Value);
+                }
+            }
+        }
+
+        internal override void SetField(string key, HoconField value)
+        {
+            Objects.Last().SetField(key, value);
+        }
+
+        private void SoftMerge(HoconObject other)
+        {
+            foreach (var kvp in other)
+            {
+                base.SetField(kvp.Key, kvp.Value);
             }
         }
 
         public override void Merge(HoconObject other)
         {
-            var owner = Objects.Last();
-            owner.Merge(other);
+            var value = new HoconValue(Parent);
+            value.Add(other.Clone(value));
+            ((HoconField)Parent).SetValue(value);
+
             //((HoconField)Parent).Value.Add(other.Clone(((HoconField)Parent).Value));
-            base.Merge(other);
+            foreach (var kvp in other)
+            {
+                base.SetField(kvp.Key, kvp.Value);
+            }
+            //base.Merge(other);
         }
         
     }

--- a/src/Hocon/Impl/HoconSubstitution.cs
+++ b/src/Hocon/Impl/HoconSubstitution.cs
@@ -65,17 +65,7 @@ namespace Hocon
             internal set
             {
                 _resolvedValue = value;
-                switch (Parent)
-                {
-                    case HoconValue v:
-                        v.ResolveValue(this);
-                        break;
-                    case HoconArray a:
-                        a.ResolveValue(this);
-                        break;
-                    default:
-                        throw new Exception($"Invalid parent type while resolving substitution:{Parent.GetType()}");
-                }
+                ((HoconValue)Parent).ResolveValue(this);
             }
         }
 
@@ -90,7 +80,13 @@ namespace Hocon
         /// /// <param name="lineInfo">The <see cref="IHoconLineInfo"/> of this substitution, used for exception generation purposes.</param>
         internal HoconSubstitution(IHoconElement parent, HoconPath path, IHoconLineInfo lineInfo, bool required)
         {
-            Parent = parent ?? throw new ArgumentNullException(nameof(parent), "Hocon substitute parent can not be null.");
+            if(parent == null)
+                throw new ArgumentNullException(nameof(parent), "Hocon substitute parent can not be null.");
+
+            if (!(parent is HoconValue))
+                throw new HoconException("HoconSubstitution parent must be HoconValue.");
+
+            Parent = parent;
             LinePosition = lineInfo.LinePosition;
             LineNumber = lineInfo.LineNumber;
             Required = required;

--- a/src/Hocon/Impl/HoconSubstitution.cs
+++ b/src/Hocon/Impl/HoconSubstitution.cs
@@ -39,6 +39,8 @@ namespace Hocon
 
         public bool Required { get; }
 
+        internal bool Removed { get; set; }
+
         internal HoconField ParentField
         {
             get  {
@@ -71,6 +73,8 @@ namespace Hocon
                     case HoconArray a:
                         a.ResolveValue(this);
                         break;
+                    default:
+                        throw new Exception($"Invalid parent type while resolving substitution:{Parent.GetType()}");
                 }
             }
         }
@@ -116,8 +120,16 @@ namespace Hocon
             => ResolvedValue.ToString(indent, indentSize);
 
         // Substitution can not be cloned because it is resolved at the end of the parsing process.
+        // TODO: check for possible bugs
         public IHoconElement Clone(IHoconElement newParent)
         {
+#if DEBUG
+            var parent = newParent;
+            while (parent != null && !(parent is HoconField))
+                parent = parent.Parent;
+            var parentField = parent as HoconField;
+            Console.WriteLine($"Substitution node was cloned. Path:{Path} to new path:{parentField?.Path}");
+#endif
             Parent = newParent;
             return this;
         }

--- a/src/Hocon/Impl/HoconSubstitution.cs
+++ b/src/Hocon/Impl/HoconSubstitution.cs
@@ -81,7 +81,7 @@ namespace Hocon
         internal HoconSubstitution(IHoconElement parent, HoconPath path, IHoconLineInfo lineInfo, bool required)
         {
             if(parent == null)
-                throw new ArgumentNullException(nameof(parent), "Hocon substitute parent can not be null.");
+                throw new ArgumentNullException(nameof(parent), "HoconSubstitution parent can not be null.");
 
             if (!(parent is HoconValue))
                 throw new HoconException("HoconSubstitution parent must be HoconValue.");
@@ -119,13 +119,21 @@ namespace Hocon
         // TODO: check for possible bugs
         public IHoconElement Clone(IHoconElement newParent)
         {
+            if (newParent == null)
+                throw new ArgumentNullException(nameof(newParent), "HoconSubstitution parent can not be null.");
+
+            if (!(newParent is HoconValue))
+                throw new HoconException("HoconSubstitution parent must be HoconValue.");
+
 #if DEBUG
             var parent = newParent;
             while (parent != null && !(parent is HoconField))
                 parent = parent.Parent;
             var parentField = parent as HoconField;
-            Console.WriteLine($"Substitution node was cloned. Path:{Path} to new path:{parentField?.Path}");
+            throw new HoconException($"Substitution node was cloned. Path:{Path} to new path:{parentField?.Path}");
+            //Console.WriteLine($"Substitution node was cloned. Path:{Path} to new path:{parentField?.Path}");
 #endif
+
             Parent = newParent;
             return this;
         }

--- a/src/Hocon/Impl/HoconValue.cs
+++ b/src/Hocon/Impl/HoconValue.cs
@@ -622,22 +622,27 @@ namespace Hocon
 
         #endregion
 
-        internal void ResolveValue(IHoconElement child)
+        internal void ResolveValue(HoconSubstitution child)
         {
             if (child.Type == HoconType.Empty)
             {
                 Remove(child);
             }
-            else if (Type == HoconType.Empty)
+            else
             {
-                Type = child.Type;
-            }
-            else if (Type != child.Type)
-            {
-                var sub = (HoconSubstitution) child;
-                throw HoconParserException.Create(sub, sub.Path, 
-                    "Invalid substitution, substituted type must match its sibling type. " +
-                    $"Sibling type:{Type}, substitution type:{child.Type}");
+                if (Type == HoconType.Empty)
+                {
+                    Type = child.Type;
+                }
+                else if (Type != child.Type)
+                {
+                    throw HoconParserException.Create(child, child.Path,
+                        "Invalid substitution, substituted type must match its sibling type. " +
+                        $"Sibling type:{Type}, substitution type:{child.Type}");
+                }
+
+                var childIndex = IndexOf(child);
+                this[childIndex] = child.ResolvedValue.Clone(this);
             }
 
             if (Parent is HoconField hoconField)

--- a/src/Hocon/Impl/Utils.cs
+++ b/src/Hocon/Impl/Utils.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -143,16 +144,20 @@ namespace Hocon
             switch (value)
             {
                 case HoconValue v:
-                    foreach (var val in v)
+                    return v.Any(n => n.IsSubstitution());
+                case HoconField f:
+                    return f.Value.Any(n => n.IsSubstitution());
+                case HoconObject o:
+                    foreach (var f in o.Values)
                     {
-                        if (val is HoconSubstitution)
+                        if (f.Value.Any(n => n.IsSubstitution()))
                             return true;
                     }
                     return false;
-                case HoconField f:
-                    foreach (var v in f.Value)
+                case HoconArray a:
+                    foreach (var v in a)
                     {
-                        if (v is HoconSubstitution)
+                        if (v.Any(n => n.IsSubstitution()))
                             return true;
                     }
                     return false;

--- a/src/Hocon/Parser.cs
+++ b/src/Hocon/Parser.cs
@@ -274,10 +274,10 @@ namespace Hocon
                 _tokens.Insert(_tokens.Count-1, new Token("}", TokenType.EndOfObject, null));
             }
 
-            _root.Add(ParseObject(_root));
+            ParseObject(ref _root);
         }
 
-        private IHoconElement ParseInclude(IHoconElement owner)
+        private HoconValue ParseInclude()
         {
             // Sanity check
             if (_tokens.Current.Type != TokenType.Include)
@@ -423,14 +423,16 @@ namespace Hocon
                 if(required)
                     throw HoconParserException.Create(includeToken, Path,
                         "Invalid Hocon include. Include was declared as required but include callback returned a null or empty string.");
-                return new HoconEmptyValue(owner);
+                return new HoconEmptyValue(null);
             }
 
             var includeRoot = new Parser().ParseText(includeHocon, false, _includeCallback);
+            /*
             if (owner != null && owner.Type != HoconType.Empty && owner.Type != includeRoot.Value.Type)
                 throw HoconParserException.Create(includeToken, Path,
                     "Invalid Hocon include. Hocon config substitution type must be the same as the field it's merged into. " +
                     $"Expected type: `{owner.Type}`, type returned by include callback: `{includeRoot.Value.Type}`");
+            */
 
             // fixup the substitution, add the current path as a prefix to the substitution path
             foreach (var substitution in includeRoot.Substitutions)
@@ -439,13 +441,17 @@ namespace Hocon
             }
             _substitutions.AddRange(includeRoot.Substitutions);
 
-            // reparent the value returned by the callback to the owner of the include declaration
-            return includeRoot.Value.Clone(owner);
+            // re-parent the value returned by the callback to the owner of the include declaration
+            return includeRoot.Value;
         }
 
         // The owner in this context can be either an object or an array.
-        private HoconObject ParseObject(IHoconElement owner)
+        private void ParseObject(ref HoconValue owner)
         {
+            if (owner == null)
+                throw HoconParserException.Create(_tokens.Current, Path,
+                    "ParseObject called with null parent.");
+
             // Sanity check
             if (_tokens.Current.Type != TokenType.StartOfObject)
                 throw HoconParserException.Create(_tokens.Current, Path,
@@ -454,20 +460,27 @@ namespace Hocon
             // Consume curly bracket
             _tokens.ToNextSignificant();
 
-            var hoconObject = new HoconObject(owner);
-            IHoconElement lastValue = null;
+            var hoconObject = owner.GetObject();
+            if (hoconObject == null)
+            {
+                hoconObject = new HoconObject(owner);
+                owner.Add(hoconObject);
+            }
+
+            var valueWasParsed = false;
             var parsing = true;
             while (parsing)
             {
                 switch (_tokens.Current.Type)
                 {
                     case TokenType.Include:
-                        if (lastValue != null)
+                        if (valueWasParsed)
                             throw HoconParserException.Create(_tokens.Current, Path,
                                 $"Failed to parse Hocon object. Expected `{TokenType.Comma}` or `{TokenType.EndOfLine}`, " +
                                 $"found `{_tokens.Current.Type}` instead.");
 
-                        lastValue = ParseInclude(hoconObject.Parent?.Parent);
+                        owner.ReParent(ParseInclude());
+                        valueWasParsed = true;
                         break;
 
                     case TokenType.LiteralValue:
@@ -477,41 +490,33 @@ namespace Hocon
                         if (_tokens.Current.Type != TokenType.LiteralValue)
                             break;
 
-                        if (lastValue != null)
+                        if (valueWasParsed)
                             throw HoconParserException.Create(_tokens.Current, Path,
                                 $"Failed to parse Hocon object. Expected `{TokenType.Comma}` or `{TokenType.EndOfLine}`, " +
                                 $"found `{_tokens.Current.Type}` instead.");
 
-                        lastValue = ParseField(hoconObject);
+                        ParseField(hoconObject);
+                        valueWasParsed = true;
                         break;
 
                     case TokenType.Comment:
                     case TokenType.EndOfLine:
-                        if(lastValue != null && !(lastValue is HoconField))
-                            ((HoconValue)hoconObject.Parent).Add(lastValue.GetObject());
-
-                        lastValue = null;
+                        valueWasParsed = false;
                         _tokens.ToNextSignificantLine();
                         break;
 
                     case TokenType.Comma:
-                        if (lastValue == null)
+                        if (!valueWasParsed)
                             throw HoconParserException.Create(_tokens.Current, Path,
                                 $"Failed to parse Hocon object. Expected `{TokenType.Assign}` or `{TokenType.StartOfObject}`, " +
                                 $"found `{_tokens.Current.Type}` instead.");
 
-                        if (!(lastValue is HoconField))
-                            ((HoconValue)hoconObject.Parent).Add(lastValue.GetObject());
-
-                        lastValue = null;
+                        valueWasParsed = false;
                         _tokens.ToNextSignificant();
                         break;
 
                     case TokenType.EndOfObject:
-                        if (lastValue != null && !(lastValue is HoconField))
-                            ((HoconValue)hoconObject.Parent).Add(lastValue.GetObject());
-
-                        lastValue = null;
+                        valueWasParsed = false;
                         parsing = false;
                         break;
 
@@ -527,8 +532,6 @@ namespace Hocon
 
             // Consume the closing curly bracket.
             _tokens.ToNextSignificant();
-
-            return hoconObject;
         }
 
         // parse path value
@@ -559,7 +562,7 @@ namespace Hocon
             return HoconPath.FromTokens(keyTokens);
         }
 
-        private HoconField ParseField(HoconObject owner)
+        private void ParseField(HoconObject owner)
         {
             // sanity check
             if(_tokens.Current.IsNonSignificant() || _tokens.Current.Type != TokenType.LiteralValue)
@@ -585,14 +588,43 @@ namespace Hocon
                 throw HoconParserException.Create(_tokens.Current, Path,
                     "Failed to parse Hocon field. Null or empty path");
 
-            var childInPath = owner.TraversePath(relativePath);
-
             Path.AddRange(relativePath);
-            var currentField = childInPath[childInPath.Count - 1];
+
+            var currentField = owner.TraversePath(relativePath);
             currentField.SetValue(ParseValue(currentField));
 
             Path.RemoveRange(Path.Count - relativePath.Count, relativePath.Count);
-            return childInPath[0];
+        }
+
+        private HoconValue GetHoconValueFromParentElement(IHoconElement parentElement, TokenType type)
+        {
+            if(parentElement is HoconArray arr)
+                return new HoconValue(arr);
+
+            if(!(parentElement is HoconField hf))
+                throw HoconParserException.Create(_tokens.Current, Path,
+                    "Invalid parent element for HoconValue. Valid objects are HoconArray and HoconField.");
+
+            var fieldValue = hf.Value;
+            if (ReferenceEquals(fieldValue, HoconValue.Undefined))
+                return new HoconValue(hf);
+
+            switch (type)
+            {
+                case TokenType.LiteralValue:
+                    return new HoconValue(hf);
+                case TokenType.StartOfObject when fieldValue.Type == HoconType.Object:
+                    return fieldValue;
+                case TokenType.StartOfArray when fieldValue.Type == HoconType.Array:
+                    return fieldValue;
+                case TokenType.SubstituteOptional:
+                case TokenType.SubstituteRequired:
+                    return new HoconValue(hf);
+                case TokenType.Include:
+                    return new HoconValue(hf);
+                default:
+                    return new HoconValue(hf);
+            }
         }
 
         /// <summary>
@@ -603,14 +635,33 @@ namespace Hocon
         /// <exception cref="System.Exception">End of file reached while trying to read a value</exception>
         private HoconValue ParseValue(IHoconElement owner)
         {
-            var value = new HoconValue(owner);
+            // value is lazy initialized because we don't know what kind of value we're parsing
+            HoconValue value = null;
             var parsing = true;
             while (parsing)
             {
                 switch (_tokens.Current.Type)
                 {
                     case TokenType.Include:
-                        value.Add(ParseInclude(owner));
+                        var includeToken = _tokens.Current;
+                        var includeValue = ParseInclude();
+                        switch (includeValue.Type)
+                        {
+                            case HoconType.Empty:
+                                value = new HoconEmptyValue(owner);
+                                break;
+                            case HoconType.Object:
+                                value = GetHoconValueFromParentElement(owner, TokenType.StartOfObject);
+                                value.ReParent(includeValue);
+                                break;
+                            case HoconType.Array:
+                                value = GetHoconValueFromParentElement(owner, TokenType.StartOfArray);
+                                value.ReParent(includeValue);
+                                break;
+                            default:
+                                throw HoconParserException.Create(includeToken, Path,
+                                    "Include could never contain a literal type.");
+                        }
                         break;
 
                     case TokenType.LiteralValue:
@@ -621,6 +672,9 @@ namespace Hocon
                         if (_tokens.Current.Type != TokenType.LiteralValue)
                             break;
 
+                        if(value == null)
+                            value = GetHoconValueFromParentElement(owner, _tokens.Current.Type);
+
                         while (_tokens.Current.Type == TokenType.LiteralValue)
                         {
                             value.Add(HoconLiteral.Create(value, _tokens.Current));
@@ -629,21 +683,40 @@ namespace Hocon
                         break;
 
                     case TokenType.StartOfObject:
-                        value.Add(ParseObject(value));
+                        if (value == null)
+                            value = GetHoconValueFromParentElement(owner, _tokens.Current.Type);
+
+                        ParseObject(ref value);
                         break;
 
                     case TokenType.StartOfArray:
+                        if (value == null)
+                            value = GetHoconValueFromParentElement(owner, _tokens.Current.Type);
                         value.Add(ParseArray(value));
                         break;
 
                     case TokenType.SubstituteOptional:
                     case TokenType.SubstituteRequired:
+                        if (value == null)
+                            value = new HoconValue(owner);
+
                         var pointerPath = HoconPath.Parse(_tokens.Current.Value);
-                        HoconSubstitution sub = new HoconSubstitution(value, pointerPath, _tokens.Current,
+                        var sub = new HoconSubstitution(value, pointerPath, _tokens.Current,
                             _tokens.Current.Type == TokenType.SubstituteRequired);
                         _substitutions.Add(sub);
-                        value.Add(sub);
                         _tokens.Next();
+                        value.Add(sub);
+                        break;
+
+                    case TokenType.PlusEqualAssign:
+                        if (value == null)
+                            value = new HoconValue(owner);
+
+                        var subAssign = new HoconSubstitution(value, new HoconPath(Path), _tokens.Current, false);
+                        _substitutions.Add(subAssign);
+                        value.Add(subAssign);
+                        value.Add(ParsePlusEqualAssignArray(value));
+                        parsing = false;
                         break;
 
                     case TokenType.EndOfObject:
@@ -664,15 +737,6 @@ namespace Hocon
                         parsing = false;
                         break;
 
-                    case TokenType.PlusEqualAssign:
-                        HoconSubstitution subAssign = new HoconSubstitution(value, new HoconPath(Path), _tokens.Current, false);
-                        _substitutions.Add(subAssign);
-                        value.Add(subAssign);
-
-                        value.Add(ParsePlusEqualAssignArray(value));
-                        parsing = false;
-                        break;
-
                     case TokenType.Assign:
                         // Special case to support end of line after assign
                         _tokens.ToNextSignificantLine();
@@ -683,6 +747,9 @@ namespace Hocon
                             $"Failed to parse Hocon value. Unexpected token: `{_tokens.Current.Type}`");
                 }
             }
+
+            if (value == null)
+                value = new HoconEmptyValue(owner);
 
             // trim trailing whitespace if result is a literal
             if (value.Type == HoconType.Literal)
@@ -709,7 +776,17 @@ namespace Hocon
             switch (_tokens.Current.Type)
             {
                 case TokenType.Include:
-                    currentArray.Add(ParseValue(currentArray));
+                    var includeToken = _tokens.Current;
+                    var includeValue = ParseInclude();
+                    if (includeValue.Type == HoconType.Empty)
+                        break;
+
+                    if(currentArray.Type != HoconType.Empty && currentArray.Type != includeValue.Type)
+                        throw HoconParserException.Create(includeToken, Path,
+                            "Invalid Hocon include. Hocon config substitution type must be the same as the field it's merged into. " +
+                            $"Expected type: `{currentArray.Type}`, type returned by include callback: `{includeValue.Type}`");
+
+                    currentArray.Add((HoconValue)includeValue.Clone(currentArray));
                     break;
 
                 case TokenType.StartOfArray:
@@ -761,19 +838,20 @@ namespace Hocon
             // consume start of array token
             _tokens.ToNextSignificant();
 
-            HoconValue lastValue = null;
+            var valueWasParsed = false;
             var parsing = true;
             while (parsing)
             {
                 switch (_tokens.Current.Type)
                 {
                     case TokenType.Include:
-                        if (lastValue != null)
+                        if (valueWasParsed)
                             throw HoconParserException.Create(_tokens.Current, Path,
                                 $"Failed to parse Hocon array. Expected `{TokenType.Comma}` or `{TokenType.EndOfLine}, " +
                                 $"found `{_tokens.Current.Type}` instead.");
 
-                        lastValue = ParseValue(currentArray);
+                        currentArray.Add(ParseValue(currentArray));
+                        valueWasParsed = true;
                         break;
 
                     case TokenType.LiteralValue:
@@ -783,77 +861,64 @@ namespace Hocon
                         if (_tokens.Current.Type != TokenType.LiteralValue)
                             break;
 
-                        if (lastValue != null)
+                        if (valueWasParsed)
                             throw HoconParserException.Create(_tokens.Current, Path,
                                 $"Failed to parse Hocon array. Expected `{TokenType.Comma}` or `{TokenType.EndOfLine}, " +
                                 $"found `{_tokens.Current.Type}` instead.");
 
-                        lastValue = ParseValue(currentArray);
+                        currentArray.Add(ParseValue(currentArray));
+                        valueWasParsed = true;
                         break;
 
                     case TokenType.StartOfObject:
-                        if (lastValue != null)
+                        if (valueWasParsed)
                             throw HoconParserException.Create(_tokens.Current, Path,
                                 $"Failed to parse Hocon array. Expected `{TokenType.Comma}` or `{TokenType.EndOfLine}, " +
                                 $"found `{_tokens.Current.Type}` instead.");
 
-                        lastValue = ParseValue(currentArray);
+                        currentArray.Add(ParseValue(currentArray));
+                        valueWasParsed = true;
                         break;
 
                     case TokenType.StartOfArray:
-                        if (lastValue != null)
+                        if (valueWasParsed)
                             throw HoconParserException.Create(_tokens.Current, Path,
                                 $"Failed to parse Hocon array. Expected `{TokenType.Comma}` or `{TokenType.EndOfLine}, " +
                                 $"found `{_tokens.Current.Type}` instead.");
 
                         // Array inside of arrays are parsed as values because it can be value concatenated with another array.
-                        lastValue = ParseValue(currentArray);
+                        currentArray.Add(ParseValue(currentArray));
+                        valueWasParsed = true;
                         break;
 
                     case TokenType.SubstituteOptional:
                     case TokenType.SubstituteRequired:
-                        if (lastValue != null)
+                        if (valueWasParsed)
                             throw HoconParserException.Create(_tokens.Current, Path,
                                 $"Failed to parse Hocon array. Expected `{TokenType.Comma}` or `{TokenType.EndOfLine}, " +
                                 $"found `{_tokens.Current.Type}` instead.");
-                        lastValue = ParseValue(currentArray);
-                        /*
-                        var pointerPath = HoconPath.Parse(_tokens.Current.Value);
-                        HoconSubstitution sub = new HoconSubstitution(currentArray, pointerPath, _tokens.Current,
-                            _tokens.Current.Type == TokenType.SubstituteRequired);
-                        _substitutions.Add(sub);
-                        lastValue = sub;
-                        _tokens.Next();
-                        */
+
+                        currentArray.Add(ParseValue(currentArray));
+                        valueWasParsed = true;
                         break;
 
                     case TokenType.EndOfArray:
-                        if (lastValue != null)
-                        {
-                            currentArray.Add(lastValue);
-                            lastValue = null;
-                        }
+                        valueWasParsed = false;
                         parsing = false;
                         break;
 
                     case TokenType.Comment:
                     case TokenType.EndOfLine:
-                        if (lastValue != null)
-                        {
-                            currentArray.Add(lastValue);
-                            lastValue = null;
-                        }
-
+                        valueWasParsed = false;
                         _tokens.ToNextSignificantLine();
                         break;
 
                     case TokenType.Comma:
-                        if (lastValue == null)
+                        if (!valueWasParsed)
                             throw HoconParserException.Create(_tokens.Current, Path,
                                 $"Failed to parse Hocon array. Expected a valid value, found `{_tokens.Current.Type}` instead.");
 
-                        currentArray.Add(lastValue);
-                        lastValue = null;
+                        valueWasParsed = false;
                         _tokens.ToNextSignificant();
                         break;
 


### PR DESCRIPTION
Bug:
Improper value instantiation and parenting during parsing caused a disconnected tree node, causing self-referencing substitution to fail to find the proper old value to backtrack to.

Fix:
- Clean up HoconField constructor and instantiation.
- Strict parenting rule for tree nodes to clean up object reconstruction.
- Move object value tracking and upkeep responsibility to the parser instead of the substitution resolver to guarantee tree hierarchy consistency,

Fix #95 
Fix #97 