### PR TITLE
Substitution environment variable fallback sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,6 @@ dlldata.c
 project.lock.json
 project.fragment.lock.json
 artifacts/
-**/Properties/launchSettings.json
 
 *_i.c
 *_p.c

--- a/src/Hocon.Extensions.Configuration.Tests/Hocon.Extensions.Configuration.Tests.csproj
+++ b/src/Hocon.Extensions.Configuration.Tests/Hocon.Extensions.Configuration.Tests.csproj
@@ -52,4 +52,8 @@
       <Generator>ResXFileCodeGenerator</Generator>
     </EmbeddedResource>
   </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
 </Project>

--- a/src/examples/Fallback/Program.cs
+++ b/src/examples/Fallback/Program.cs
@@ -17,7 +17,10 @@ namespace Fallback
             var baseHocon = @"
 root {
    some-property1 = 123
-   some-property2 = 234  
+   some-property2 = 234 
+   // This property is set through environment variable.
+   // On debug mode, it is set inside the debug tab in the project properties.
+   environment-property = ${?ENV_MY_PROPERTY} 
 }
 ";
             var userHocon = @"
@@ -34,10 +37,12 @@ root {
             var val1 = merged.GetString("root.some-property1");
             var val2 = merged.GetString("root.some-property2");
             var val3 = merged.GetString("root.some-property3");
+            var envVal = merged.GetString("root.environment-property");
 
             Console.WriteLine("root.some-property1 = {0}", val1);
             Console.WriteLine("root.some-property2 = {0}", val2);
             Console.WriteLine("root.some-property3 = {0}", val3);
+            Console.WriteLine("root.environment-property = {0}", envVal);
 
             Console.ReadKey();
         }

--- a/src/examples/Fallback/Program.cs
+++ b/src/examples/Fallback/Program.cs
@@ -14,12 +14,12 @@ namespace Fallback
     {
         static void Main(string[] args)
         {
+            // The "environment-property" property is set through environment variable.
+            // On debug mode, it is set inside the debug tab in the project properties.
             var baseHocon = @"
 root {
    some-property1 = 123
    some-property2 = 234 
-   // This property is set through environment variable.
-   // On debug mode, it is set inside the debug tab in the project properties.
    environment-property = ${?ENV_MY_PROPERTY} 
 }
 ";
@@ -37,12 +37,16 @@ root {
             var val1 = merged.GetString("root.some-property1");
             var val2 = merged.GetString("root.some-property2");
             var val3 = merged.GetString("root.some-property3");
-            var envVal = merged.GetString("root.environment-property");
 
             Console.WriteLine("root.some-property1 = {0}", val1);
             Console.WriteLine("root.some-property2 = {0}", val2);
             Console.WriteLine("root.some-property3 = {0}", val3);
-            Console.WriteLine("root.environment-property = {0}", envVal);
+
+            if (merged.HasPath("root.environment-property"))
+            {
+                var envVal = merged.GetString("root.environment-property");
+                Console.WriteLine("root.environment-property = {0}", envVal);
+            }
 
             Console.ReadKey();
         }

--- a/src/examples/Fallback/Properties/launchSettings.json
+++ b/src/examples/Fallback/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "Fallback": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "ENV_MY_PROPERTY": "My environment value"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add a simple environment variable substitution fallback sample to the Fallback sample project.
For debug mode, MY_ENV_PROPERTY is set inside the project properties under Debug tab.
For release mode, the user have to set the environment variable themselves before running the console app.