### PR TITLE
Fixed merge for substitutions

### DIFF
--- a/src/Hocon.Configuration.Test/ConfigurationSpec.cs
+++ b/src/Hocon.Configuration.Test/ConfigurationSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Configuration;
 using System.Linq;
+using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -272,6 +273,26 @@ a {
             var enumerable = config2.AsEnumerable();
 
             Assert.Equal("some quoted, key", enumerable.Select(kvp => kvp.Key).First());
+        }
+        
+        [Fact]
+        public void CanSubstituteArrayCorrectly()
+        {
+            var hocon = @"
+ c: {
+    q: {
+        a: [2, 5]
+    }
+}
+c: {
+    m: ${c.q} {a: [6]}
+}
+";
+            var config = ConfigurationFactory.ParseString(hocon);
+            var unchanged = config.GetIntList("c.q.a");
+            unchanged.Should().Equal(new [] { 2, 5 });
+            var changed = config.GetIntList("c.m.a");
+            changed.Should().Equal(new [] { 6 });
         }
 
         [Fact]

--- a/src/Hocon.Configuration.Test/Hocon.Configuration.Tests.csproj
+++ b/src/Hocon.Configuration.Test/Hocon.Configuration.Tests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="$(XunitCliVersion)" />

--- a/src/Hocon/Extensions/HoconElementExtensions.cs
+++ b/src/Hocon/Extensions/HoconElementExtensions.cs
@@ -1,0 +1,19 @@
+namespace Hocon.Extensions
+{
+    /// <summary>
+    /// HoconElementExtensions
+    /// </summary>
+    public static class HoconElementExtensions
+    {
+        /// <summary>
+        /// Performs deep clone of the element's value.
+        /// This is generally the same as <see cref="IHoconElement.Clone"/>, but
+        /// for substitutions it returns the substitution itself since it's value will be closed
+        /// during resolution process.
+        /// </summary>
+        public static IHoconElement CloneValue(this IHoconElement hoconElement, IHoconElement newParent)
+        {
+            return hoconElement is HoconSubstitution ? hoconElement : hoconElement.Clone(newParent);
+        }
+    }
+}

--- a/src/Hocon/Impl/HoconObject.cs
+++ b/src/Hocon/Impl/HoconObject.cs
@@ -394,7 +394,7 @@ namespace Hocon
             var clone = new HoconObject(newParent);
             foreach (var kvp in this)
             {
-                clone.SetField(kvp.Key, kvp.Value);
+                clone.SetField(kvp.Key, kvp.Value.Clone(clone) as HoconField);
             }
             return clone;
         }

--- a/src/Hocon/Impl/HoconObject.cs
+++ b/src/Hocon/Impl/HoconObject.cs
@@ -11,6 +11,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices.ComTypes;
 using System.Text;
+using Hocon.Extensions;
 
 namespace Hocon
 {
@@ -394,7 +395,7 @@ namespace Hocon
             var clone = new HoconObject(newParent);
             foreach (var kvp in this)
             {
-                clone.SetField(kvp.Key, kvp.Value.Clone(clone) as HoconField);
+                clone.SetField(kvp.Key, kvp.Value.CloneValue(clone) as HoconField);
             }
             return clone;
         }

--- a/src/Hocon/Impl/HoconValue.cs
+++ b/src/Hocon/Impl/HoconValue.cs
@@ -706,7 +706,7 @@ namespace Hocon
             var clone = new HoconValue(newParent);
             foreach (var element in this)
             {
-                clone.Add(element);
+                clone.Add(element.Clone(clone));
             }
             return clone;
         }

--- a/src/Hocon/Impl/HoconValue.cs
+++ b/src/Hocon/Impl/HoconValue.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
+using Hocon.Extensions;
 
 namespace Hocon
 {
@@ -706,7 +707,7 @@ namespace Hocon
             var clone = new HoconValue(newParent);
             foreach (var element in this)
             {
-                clone.Add(element.Clone(clone));
+                clone.Add(element.CloneValue(clone));
             }
             return clone;
         }

--- a/src/Hocon/Parser.cs
+++ b/src/Hocon/Parser.cs
@@ -184,7 +184,7 @@ namespace Hocon
 
             // third case, regular substitution
             _root.GetObject().TryGetValue(sub.Path, out var field);
-            return field;
+            return field.Clone(field.Parent) as HoconValue;
         }
 
         private bool IsValueCyclic(HoconField field, HoconSubstitution sub)

--- a/src/Hocon/Parser.cs
+++ b/src/Hocon/Parser.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="Parser.cs" company="Hocon Project">
 //     Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2018 .NET Foundation <https://github.com/akkadotnet/hocon>
@@ -184,7 +184,7 @@ namespace Hocon
 
             // third case, regular substitution
             _root.GetObject().TryGetValue(sub.Path, out var field);
-            return field.Clone(field.Parent) as HoconValue;
+            return field?.Clone(field.Parent) as HoconValue;
         }
 
         private bool IsValueCyclic(HoconField field, HoconSubstitution sub)


### PR DESCRIPTION
Close #127 

The basic idea of the fix is that in current implementation substitution takes value "by reference" - which means that when object merge occurs the initial value, referenced in substitution, is modified. This could lead to lots of issues, not only with the once described in closing issue.

So the fix is basically make substitution to just deeply copy referenced sub-tree, so that it was safe to modify.

In the edge case when we do not need to modify referenced object we could still keep the "be reference" behavior instead of "by value". Not sure if it will save much performance and if it is important at all. But checking if we are somehow, somewhere modifying substituted value (not to say that we could reference one sub-tree, that includes another substitution that could also be modified then) - too complicated. So let's just take it by value and sleep soundly at night.