### PR TITLE
Fix arrays merge

### DIFF
--- a/src/Hocon.Tests/DuplicateKeysAndObjectMerging.cs
+++ b/src/Hocon.Tests/DuplicateKeysAndObjectMerging.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -145,6 +146,27 @@ foo
             Assert.Equal(1, config.GetInt("foo.x"));
             Assert.Equal(2, config.GetInt("foo.y"));
             Assert.Equal(32, config.GetInt("foo.z"));
+        }
+
+        // Fix for https://github.com/akkadotnet/HOCON/issues/137
+        [Fact]
+        public void ObjectsWithArraysShouldMergeCorrectly()
+        {
+            var hocon = @"
+c: { 
+    a: [2, 5] 
+    a: [6] 
+}
+";
+            var hocon2 = @"
+c: { 
+    a: [2, 5] [6] 
+}
+";
+            var config = Parser.Parse(hocon);
+            config.GetIntList("c.a").Should().Equal(new [] { 6 });
+            config = Parser.Parse(hocon2);
+            config.GetIntList("c.a").Should().Equal(new [] { 2, 5, 6 });
         }
 
         [Fact]

--- a/src/Hocon.Tests/Hocon.Tests.csproj
+++ b/src/Hocon.Tests/Hocon.Tests.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="$(XunitCliVersion)" />

--- a/src/Hocon/Parser.cs
+++ b/src/Hocon/Parser.cs
@@ -690,6 +690,11 @@ namespace Hocon
                     case TokenType.StartOfArray:
                         if (value == null)
                             value = GetHoconValueFromParentElement(owner, _tokens.Current.Type);
+                        
+                        // If this array is already initialized, we are going to overwrite it
+                        if (value.Type == HoconType.Array && value.Count > 0)
+                            value.Clear();
+                        
                         value.Add(ParseArray(value));
                         break;
 
@@ -902,7 +907,19 @@ namespace Hocon
 
                     case TokenType.EndOfArray:
                         valueWasParsed = false;
-                        parsing = false;
+
+                        // If there is a next array on the same like - let's move to it's first element
+                        if (_tokens.ForwardMatch(TokenType.StartOfArray))
+                        {
+                            _tokens.ToNextSignificant();
+                            _tokens.Next();
+                        }
+                        else
+                        {
+                            // Otherwise, array value is fully loaded and nothing to do here
+                            parsing = false;
+                        }
+                        
                         break;
 
                     case TokenType.Comment:


### PR DESCRIPTION
Close #137 

While debugging, it turned out that what current implementation does is taking value by key (create if not exists) and append array values to it.

So, actually, the following:
```
c: {
    a: [2. 3]
    b: [4]
    a: [5]
}
```

was ending up with `a = [2, 3, 5]`. So, arrays with same paths were always concatenating, as if one was continuation of another.

And as far as I understand the specs, the only case when arrays are concatenated is when they are separated with non-newline while space. From README:
```
Within an field value or array element, if only non-newline white-space separates the end of a first array or object or substitution from the start of a second array or object or substitution, the two values are concatenated.
```

So for me, this is a special case that should be explicitly handled. Like when you have `]` token, check if next tokens are some white-spaces and then `[` token - and in that case just skip this part and keep going.

So, that is what basically my fix is doing:
1) When we find second key with same path (i.e. second `a`) and there is already existing array, do not concatenate them (I am calling `Clear` on old value)
2) When during array parsing we have a special case described above, do the "special thing"