### PR TITLE
Fix parsing of quoted keys

### DIFF
--- a/src/Hocon.Tests/HoconTests.cs
+++ b/src/Hocon.Tests/HoconTests.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="HoconTests.cs" company="Hocon Project">
 //     Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2018 .NET Foundation <https://github.com/akkadotnet/hocon>
@@ -228,6 +228,19 @@ a {
 }
 ";
             Assert.Equal("1", Parser.Parse(hocon).GetString("a.b"));
+        }
+
+        [Fact]
+        public void CanParseQuotedElements()
+        {
+            var hocon = @"
+A.B = 1
+A {
+ ""X.Y"" = 1
+}
+";
+            var ex = Record.Exception(() => Parser.Parse(hocon).GetObject("A"));
+            Assert.Null(ex);
         }
 
         [Fact]

--- a/src/Hocon/Impl/HoconObject.cs
+++ b/src/Hocon/Impl/HoconObject.cs
@@ -171,9 +171,15 @@ namespace Hocon
 
             if (path.Count == 0)
                 throw new ArgumentException("Path is empty.", nameof(path));
-
-            var pathIndex = 0;
+            
             var currentObject = this;
+            
+            // Sometimes path may be a double-quoted string like "a.b.c" with quotes ommited,
+            // so check if there is such key first
+            if (currentObject.TryGetValue(path.ToString(), out var rootField))
+                return rootField;
+            
+            var pathIndex = 0;
             while (true)
             {
                 var key = path[pathIndex];


### PR DESCRIPTION
Close #125 

So, here is the issue: during parsing of hocon object, we need to store object's keys. And with double-quoted keys, if we will include `'"'` sign in the key, we will not be able to make requests like `config.GetInt("a")` if `a` was double-quoted. Or, if we will omit `'"'` sign when storing the key ) which looks better, and this is what we are doing) - we will loose information that this key was double-quoted.

This information is not that important - until we will try to get value from object by it's path. That is exactly what happens when we call `config.GetObject("A")` for example - recursively it will iterate children, using keys of the object like hocon paths.

And guess what - for double-quoted key "X.Y" we have hocon path "X.Y" (we do not know that is was double-quoted, so it is handled like `X -> Y`), but object has `X.Y` key, and does not have `X`. So that's why we are getting error.

After some experiments with keeping double-quotes in keys and other stuff, I ended up with idea that it is better to think about such keys lookup as a special case - and each time when we are requesting child by hocon path, I am just checking if full path is preset in object's keys. So for path `X.Y` it will check `X.Y`, and then `X` -> `Y`. 