### PR TITLE
Fix removing substitutions that are still to be resolved

### DIFF
--- a/src/Hocon.Tests/HoconTests.cs
+++ b/src/Hocon.Tests/HoconTests.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -305,6 +306,37 @@ a.b.e.f=3
             Assert.Equal(1L, config.GetLong("a.b.c"));
             Assert.Equal(2L, config.GetLong("a.b.d"));
             Assert.Equal(3L, config.GetLong("a.b.e.f"));
+        }
+
+        [Fact]
+        public void Fix_substitutions_Issue123()
+        {
+            var hocon = @"
+a: avalue
+
+b {
+  b1: ""0001-01-01Z""
+  b2: 0
+  b_alpha: ${a}/${c.c1}/${b.b3}/${b.b4}
+  b_beta: ""[""${b.b_alpha}"",""${b.b1}"",""${b.b2}""]""
+}
+
+c {
+  c1: c1value
+}
+
+b {
+  b3: b4value
+}
+
+b {
+  b4: b4value
+}
+";
+
+            var config = Parser.Parse(hocon);
+            config.GetString("b.b_alpha").Should().Be("avalue/c1value/b4value/b4value");
+            config.GetString("b.b_beta").Should().Be("[avalue/c1value/b4value/b4value,0001-01-01Z,0]");
         }
 
         [Fact]

--- a/src/Hocon.Tests/HoconTests.cs
+++ b/src/Hocon.Tests/HoconTests.cs
@@ -124,7 +124,7 @@ a {
 
         //Added tests to conform to the HOCON spec https://github.com/typesafehub/config/blob/master/HOCON.md
         [Fact]
-        public void CanUsePathsAsKeys_3_14()
+        public void CanUsePathsAsKeys_3_14() 
         {
             var hocon1 = @"3.14 : 42";
             var hocon2 = @"3 { 14 : 42}";

--- a/src/Hocon.Tests/SelfReferentialSubstitution.cs
+++ b/src/Hocon.Tests/SelfReferentialSubstitution.cs
@@ -186,7 +186,10 @@ foo : { a : 1 }
         {
             var hocon = @"
 foo : ${does-not-exist}
-foo : 42";
+foo : 42
+bar : ${yet-another-to-ignore}
+bar : [42]
+";
 
             HoconRoot config = null;
             var ex = Record.Exception(() => config = Parser.Parse(hocon));

--- a/src/Hocon/Impl/HoconField.cs
+++ b/src/Hocon/Impl/HoconField.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="HoconField.cs" company="Hocon Project">
 //     Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2018 .NET Foundation <https://github.com/akkadotnet/hocon>
@@ -96,7 +96,7 @@ namespace Hocon
             if (value == null)
                 return;
 
-            if (value.Type == HoconType.Literal)
+            if (value.Type != HoconType.Object)
             {
                 foreach (var item in _internalValues)
                 {

--- a/src/Hocon/Impl/HoconField.cs
+++ b/src/Hocon/Impl/HoconField.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------
 // <copyright file="HoconField.cs" company="Hocon Project">
 //     Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2018 .NET Foundation <https://github.com/akkadotnet/hocon>
@@ -101,7 +101,8 @@ namespace Hocon
                 foreach (var item in _internalValues)
                 {
                     var subs = item.GetSubstitutions();
-                    foreach (var sub in subs)
+                    var preservedSub = value.GetSubstitutions();
+                    foreach (var sub in subs.Except(preservedSub))
                     {
                         sub.Removed = true;
                     }


### PR DESCRIPTION
Close #123

The problem here was that when setting value to some object's key, we were deleting all substitutions from the old value - even if the same substitutions were used in new value. 

Also, noticed that rewriting value was used only for literals. I.e. 
```
foo = ${not-exists}
foo = [42]
```
was failing, since it did not allow arrays to overwrite values. Which is of course a bug. Fixed as it was almost in the same line.