### PR TITLE
added v1.2.1 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,7 +5,7 @@ HOCON 1.2.1 contains many minor bug fixes and behavioral changes.
 Per [issue 151](https://github.com/akkadotnet/HOCON/issues/151), `HOCON.Configuration` now looks for default HOCON content in the following places in the following order:
 
 1. [.NET Core / .NET Framework] An "app.conf" or an "app.hocon" file in the current working directory of the executable when it loads;
-2. [.NET Framework] - the `<hocon>` `ConfigurationSection` inside `App.config` or `Web.config`, which should also resolve #8 and #9 
+2. [.NET Framework] - the `<hocon>` `ConfigurationSection` inside `App.config` or `Web.config`; or
 3. [.NET Framework] - and a legacy option, to load the old `<akka>` HOCON section for backwards compatibility purposes with all users who have been using HOCON with Akka.NET.
 
 **Bug fixes**:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-#### 1.2.1 December 21 2019 ####
+#### 1.2.1 December 27 2019 ####
 HOCON 1.2.1 contains many minor bug fixes and behavioral changes.
 
 **Default HOCON loading order**

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,2 +1,12 @@
-#### 1.2.0 October 05 2019 ####
-HOCON 1.2.0 contains an entirely new model for working with HOCON, via the `Hocon.Immutable` NuGet package.
+#### 1.2.1 December 21 2019 ####
+HOCON 1.2.1 contains many minor bug fixes and behavioral changes.
+
+**Default HOCON loading order**
+Per [issue 151](https://github.com/akkadotnet/HOCON/issues/151), `HOCON.Configuration` now looks for default HOCON content in the following places in the following order:
+
+1. [.NET Core / .NET Framework] An "app.conf" or an "app.hocon" file in the current working directory of the executable when it loads;
+2. [.NET Framework] - the `<hocon>` `ConfigurationSection` inside `App.config` or `Web.config`, which should also resolve #8 and #9 
+3. [.NET Framework] - and a legacy option, to load the old `<akka>` HOCON section for backwards compatibility purposes with all users who have been using HOCON with Akka.NET.
+
+**Bug fixes**:
+For a set of complete bug fixes and changes, please see [the HOCON v1.2.1 milestone on Github](https://github.com/akkadotnet/HOCON/milestone/2).

--- a/src/common.props
+++ b/src/common.props
@@ -7,7 +7,7 @@
 Default HOCON loading order**
 Per [issue 151](https://github.com/akkadotnet/HOCON/issues/151), `HOCON.Configuration` now looks for default HOCON content in the following places in the following order:
 1. [.NET Core / .NET Framework] An "app.conf" or an "app.hocon" file in the current working directory of the executable when it loads;
-2. [.NET Framework] - the `&lt;hocon&gt;` `ConfigurationSection` inside `App.config` or `Web.config`, which should also resolve #8 and #9
+2. [.NET Framework] - the `&lt;hocon&gt;` `ConfigurationSection` inside `App.config` or `Web.config`; or
 3. [.NET Framework] - and a legacy option, to load the old `&lt;akka&gt;` HOCON section for backwards compatibility purposes with all users who have been using HOCON with Akka.NET.
 Bug fixes**:
 For a set of complete bug fixes and changes, please see [the HOCON v1.2.1 milestone on Github](https://github.com/akkadotnet/HOCON/milestone/2).</PackageReleaseNotes>

--- a/src/common.props
+++ b/src/common.props
@@ -2,8 +2,15 @@
   <PropertyGroup>
     <Copyright>Copyright © 2014-2019 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.2.0</VersionPrefix>
-    <PackageReleaseNotes>HOCON 1.2.0 contains an entirely new model for working with HOCON, via the `Hocon.Immutable` NuGet package.</PackageReleaseNotes>
+    <VersionPrefix>1.2.1</VersionPrefix>
+    <PackageReleaseNotes>HOCON 1.2.1 contains many minor bug fixes and behavioral changes.
+Default HOCON loading order**
+Per [issue 151](https://github.com/akkadotnet/HOCON/issues/151), `HOCON.Configuration` now looks for default HOCON content in the following places in the following order:
+1. [.NET Core / .NET Framework] An "app.conf" or an "app.hocon" file in the current working directory of the executable when it loads;
+2. [.NET Framework] - the `&lt;hocon&gt;` `ConfigurationSection` inside `App.config` or `Web.config`, which should also resolve #8 and #9
+3. [.NET Framework] - and a legacy option, to load the old `&lt;akka&gt;` HOCON section for backwards compatibility purposes with all users who have been using HOCON with Akka.NET.
+Bug fixes**:
+For a set of complete bug fixes and changes, please see [the HOCON v1.2.1 milestone on Github](https://github.com/akkadotnet/HOCON/milestone/2).</PackageReleaseNotes>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/HOCON</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/HOCON/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
#### 1.2.1 December 27 2019 ####
HOCON 1.2.1 contains many minor bug fixes and behavioral changes.

**Default HOCON loading order**
Per [issue 151](https://github.com/akkadotnet/HOCON/issues/151), `HOCON.Configuration` now looks for default HOCON content in the following places in the following order:

1. [.NET Core / .NET Framework] An "app.conf" or an "app.hocon" file in the current working directory of the executable when it loads;
2. [.NET Framework] - the `<hocon>` `ConfigurationSection` inside `App.config` or `Web.config`, which should also resolve #8 and #9 
3. [.NET Framework] - and a legacy option, to load the old `<akka>` HOCON section for backwards compatibility purposes with all users who have been using HOCON with Akka.NET.

**Bug fixes**:
For a set of complete bug fixes and changes, please see [the HOCON v1.2.1 milestone on Github](https://github.com/akkadotnet/HOCON/milestone/2).