### PR TITLE
Add config.ToString(bool useFallbackValues) overload to include fallback values

### DIFF
--- a/src/Hocon.Configuration.Test/ConfigurationSpec.cs
+++ b/src/Hocon.Configuration.Test/ConfigurationSpec.cs
@@ -272,7 +272,8 @@ foo {
 
             var c = a.WithFallback(b);
             c.GetInt("akka.other-key").Should().Be(42, "Fallback value should exist as data");
-            c.ToString().Should().Contain("other-key", "Fallback value should be presented in string");
+            c.ToString().Should().NotContain("other-key", "Fallback values are ignored by default");
+            c.ToString(useFallbackValues: true).Should().Contain("other-key", "Fallback values should be displayed when requested");
         }
 
         [Fact]

--- a/src/Hocon.Configuration.Test/ConfigurationSpec.cs
+++ b/src/Hocon.Configuration.Test/ConfigurationSpec.cs
@@ -261,6 +261,21 @@ foo {
         }
 
         [Fact]
+        public void ShouldSerializeFallbackValues()
+        {
+            var a = ConfigurationFactory.ParseString(@" akka : {
+                some-key : value
+            }");
+            var b = ConfigurationFactory.ParseString(@"akka : {
+                other-key : 42
+            }");
+
+            var c = a.WithFallback(b);
+            c.GetInt("akka.other-key").Should().Be(42, "Fallback value should exist as data");
+            c.ToString().Should().Contain("other-key", "Fallback value should be presented in string");
+        }
+
+        [Fact]
         public void CanParseQuotedKeys()
         {
             var hocon = @"

--- a/src/Hocon.Configuration/Config.cs
+++ b/src/Hocon.Configuration/Config.cs
@@ -52,6 +52,22 @@ namespace Hocon
         }
 
         /// <summary>
+        /// Returns string representation of <see cref="Config"/>, allowing to include fallback values
+        /// </summary>
+        /// <param name="useFallbackValues">If set to <c>true</c>, fallback values are included in the output</param>
+        public string ToString(bool useFallbackValues)
+        {
+            if (!useFallbackValues)
+                return base.ToString();
+
+            var config = this;
+            while (config.Fallback != null)
+                config = config.Fallback;
+
+            return config.ToString();
+        }
+
+        /// <summary>
         /// Generates a deep clone of the current configuration.
         /// </summary>
         /// <returns>A deep clone of the current configuration</returns>


### PR DESCRIPTION
Close #161

Just added overload for `config.ToString()` method, that would allow to dump all fallback values.