### PR TITLE
added v1.3.0 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,12 +1,9 @@
-#### 1.2.2 December 27 2019 ####
-HOCON 1.2.1 contains many minor bug fixes and behavioral changes.
+#### 1.3.0 January 14 2020 ####
+HOCON 1.3.0 contains some significant API changes:
 
-**Default HOCON loading order**
-Per [issue 151](https://github.com/akkadotnet/HOCON/issues/151), `HOCON.Configuration` now looks for default HOCON content in the following places in the following order:
+* [API parity with pre-existing Akka.NET HOCON implementation](https://github.com/akkadotnet/HOCON/issues/157)
+* Added `HoconType.String`, `HoconType.Number`, `HoconType.Bool`, and removed `HoconType.Literal` - now it's possible to discover data types more easily while inspecting individual HOCON objects.
+* [Fixed: Need to be able to include Config fallback values to string representation](https://github.com/akkadotnet/HOCON/issues/161)
+* [Added SourceLink.Github support](https://github.com/akkadotnet/HOCON/pull/166)
 
-1. [.NET Core / .NET Framework] An "app.conf" or an "app.hocon" file in the current working directory of the executable when it loads;
-2. [.NET Framework] - the `<hocon>` `ConfigurationSection` inside `App.config` or `Web.config`; or
-3. [.NET Framework] - and a legacy option, to load the old `<akka>` HOCON section for backwards compatibility purposes with all users who have been using HOCON with Akka.NET.
-
-**Bug fixes**:
-For a set of complete bug fixes and changes, please see [the HOCON v1.2.1 milestone on Github](https://github.com/akkadotnet/HOCON/milestone/2).
+For a set of complete bug fixes and changes, please see [the HOCON v1.3.0 milestone on Github](https://github.com/akkadotnet/HOCON/milestone/3).

--- a/src/common.props
+++ b/src/common.props
@@ -2,15 +2,13 @@
   <PropertyGroup>
     <Copyright>Copyright © 2014-2019 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.2.2</VersionPrefix>
-    <PackageReleaseNotes>HOCON 1.2.1 contains many minor bug fixes and behavioral changes.
-Default HOCON loading order**
-Per [issue 151](https://github.com/akkadotnet/HOCON/issues/151), `HOCON.Configuration` now looks for default HOCON content in the following places in the following order:
-1. [.NET Core / .NET Framework] An "app.conf" or an "app.hocon" file in the current working directory of the executable when it loads;
-2. [.NET Framework] - the `&lt;hocon&gt;` `ConfigurationSection` inside `App.config` or `Web.config`; or
-3. [.NET Framework] - and a legacy option, to load the old `&lt;akka&gt;` HOCON section for backwards compatibility purposes with all users who have been using HOCON with Akka.NET.
-Bug fixes**:
-For a set of complete bug fixes and changes, please see [the HOCON v1.2.1 milestone on Github](https://github.com/akkadotnet/HOCON/milestone/2).</PackageReleaseNotes>
+    <VersionPrefix>1.3.0</VersionPrefix>
+    <PackageReleaseNotes>HOCON 1.3.0 contains some significant API changes:
+[API parity with pre-existing Akka.NET HOCON implementation](https://github.com/akkadotnet/HOCON/issues/157)
+Added `HoconType.String`, `HoconType.Number`, `HoconType.Bool`, and removed `HoconType.Literal` - now it's possible to discover data types more easily while inspecting individual HOCON objects.
+[Fixed: Need to be able to include Config fallback values to string representation](https://github.com/akkadotnet/HOCON/issues/161)
+[Added SourceLink.Github support](https://github.com/akkadotnet/HOCON/pull/166)
+For a set of complete bug fixes and changes, please see [the HOCON v1.3.0 milestone on Github](https://github.com/akkadotnet/HOCON/milestone/3).</PackageReleaseNotes>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/HOCON</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/HOCON/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
#### 1.3.0 January 14 2020 ####
HOCON 1.3.0 contains some significant API changes:

* [API parity with pre-existing Akka.NET HOCON implementation](https://github.com/akkadotnet/HOCON/issues/157)
* Added `HoconType.String`, `HoconType.Number`, `HoconType.Bool`, and removed `HoconType.Literal` - now it's possible to discover data types more easily while inspecting individual HOCON objects.
* [Fixed: Need to be able to include Config fallback values to string representation](https://github.com/akkadotnet/HOCON/issues/161)
* [Added SourceLink.Github support](https://github.com/akkadotnet/HOCON/pull/166)

For a set of complete bug fixes and changes, please see [the HOCON v1.3.0 milestone on Github](https://github.com/akkadotnet/HOCON/milestone/3).