### PR TITLE
Config.Root should contain fallback values 

### DIFF
--- a/src/Hocon.Configuration.Test/ConfigurationSpec.cs
+++ b/src/Hocon.Configuration.Test/ConfigurationSpec.cs
@@ -391,6 +391,19 @@ foo {
             ConfigurationFactory.Empty.IsEmpty.Should().BeTrue();
         }
 
+        [Fact]
+        public void HoconValue_GetObject_should_use_fallback_values()
+        {
+            var config1 = ConfigurationFactory.ParseString("a = 5");
+            var config2 = ConfigurationFactory.ParseString("b = 3");
+            var config = config1.WithFallback(config2);
+            var rootObject = config.Root.GetObject();
+            rootObject.ContainsKey("a").Should().BeTrue();
+            rootObject["a"].Raw.Should().Be("5");
+            rootObject.ContainsKey("b").Should().BeTrue();
+            rootObject["b"].Raw.Should().Be("3");
+        }
+
 
 #if !NETCORE
         [Fact]
@@ -423,9 +436,15 @@ foo {
             }");
 
             var c = a.WithFallback(b);
+            
             c.GetInt("akka.other-key").Should().Be(42, "Fallback value should exist as data");
             c.ToString().Should().NotContain("other-key", "Fallback values are ignored by default");
             c.ToString(true).Should().Contain("other-key", "Fallback values should be displayed when requested");
+            
+            c.GetString("akka.some-key").Should().Be("value", "Original value should remain");
+            c.ToString().Should().Contain("some-key", "Original values are shown by default");
+            c.ToString(true).Should().Contain("some-key", "Original values should be displayed always");
+
         }
     }
 }

--- a/src/Hocon.Configuration/Config.cs
+++ b/src/Hocon.Configuration/Config.cs
@@ -111,20 +111,17 @@ namespace Hocon
 
         protected override HoconValue GetNode(HoconPath path, bool throwIfNotFound = false)
         {
-            HoconValue result;
             try
             {
-                result = Value.GetObject().GetValue(path);
+                return Root.GetObject().GetValue(path);
             }
             catch
             {
                 if (throwIfNotFound)
                     throw;
 
-                result = Fallback?.GetNode(path);
+                return null;
             }
-
-            return result;
         }
 
         /// <summary>
@@ -141,12 +138,6 @@ namespace Hocon
         public virtual Config GetConfig(HoconPath path)
         {
             var value = GetNode(path);
-            if (Fallback != null)
-            {
-                var f = Fallback.GetConfig(path);
-                return value == null ? f : new Config(new HoconRoot(value)).WithFallback(f);
-            }
-
             return value == null ? null : new Config(new HoconRoot(value));
         }
 
@@ -206,19 +197,13 @@ namespace Hocon
         public override IEnumerable<KeyValuePair<string, HoconField>> AsEnumerable()
         {
             var used = new HashSet<string>();
-            var current = this;
-            while (current != null)
+            foreach (var kvp in Root.GetObject())
             {
-                foreach (var kvp in current.Value.GetObject())
-                {
-                    if (used.Contains(kvp.Key))
-                        continue;
+                if (used.Contains(kvp.Key))
+                    continue;
 
-                    yield return kvp;
-                    used.Add(kvp.Key);
-                }
-
-                current = current.Fallback;
+                yield return kvp;
+                used.Add(kvp.Key);
             }
         }
     }


### PR DESCRIPTION
Close #177

The issue turned out to be little bit deeper then I thought at start.
Assuming that `config` has fallback values, `config.Root.GetObject()` returns object not containing fallback values because `Root` property of type `HoconValue` does not contain them.

Hocon core library does not work with fallbacks in any way - so `HoconValue` does not have any information about possible fallbacks it has.
So the way to go is to aggregate all fallback values into Root property, which is what I am doing. Since `HoconValue` type is mutable, making separate value and putting values in reverse order - to support proper fallbacks ordering when hocon will merge inner objects.

Also, seems like few more functions in `Config` file were trying to check if any fallbacks exist - there is no need to do this anymore, since we always have magic `Root` value that already contains aggregated `HoconValue` with all fallbacks included.

Added more tests to verify that deep objects merge correctly. And, important thing - fixed `config.ToString(useFallbackValues: true)` implementation, since old one was dropping original values and was only using fallback values. Updated test for this as well.