### PR TITLE
Use fallback values of fallbacks when calculating final config

### DIFF
--- a/src/Hocon.Configuration.Test/ConfigurationSpec.cs
+++ b/src/Hocon.Configuration.Test/ConfigurationSpec.cs
@@ -45,6 +45,18 @@ a {
             Assert.Equal("some quoted, key", enumerable.Select(kvp => kvp.Key).First());
         }
 
+        [Fact]
+        public void Using_another_config_with_fallback_as_fallback_itself_Should_work()
+        {
+            var config = ConfigurationFactory.ParseString("a = 1");
+            var fallback = ConfigurationFactory.ParseString("b = 2");
+            var configWithFallback = config.WithFallback(fallback);
+
+            var anotherConfig = ConfigurationFactory.ParseString("c = 1");
+            var merged = anotherConfig.WithFallback(configWithFallback);
+            merged.GetInt("b").Should().Be(2);
+        }
+
         /// <summary>
         ///     Should follow the load order rules specified in https://github.com/akkadotnet/HOCON/issues/151
         /// </summary>

--- a/src/Hocon.Configuration.Test/DebuggerSpec.cs
+++ b/src/Hocon.Configuration.Test/DebuggerSpec.cs
@@ -99,7 +99,7 @@ namespace Hocon.Configuration.Tests
                 .SafeWithFallback(myHocon2)
                 .SafeWithFallback(myHocon3);
 
-            //fullHocon.GetString("akka.remote.transport").Should().Be("foo");
+            fullHocon.GetString("akka.remote.transport").Should().Be("foo");
 
             var dump = fullHocon.DumpConfig();
             dump.Should().Contain(myHocon1.PrettyPrint(2));

--- a/src/Hocon.Configuration/Config.cs
+++ b/src/Hocon.Configuration/Config.cs
@@ -64,7 +64,7 @@ namespace Hocon
             get
             {
                 var elements = new List<IHoconElement>();
-                for (var config = this; config != null; config = config.Fallback)
+                for (var config = this; config != null; config = config.Fallback?.Copy())
                 {
                     elements.AddRange(config.Value);
                 }

--- a/src/Hocon.Configuration/Config.cs
+++ b/src/Hocon.Configuration/Config.cs
@@ -64,9 +64,13 @@ namespace Hocon
             get
             {
                 var elements = new List<IHoconElement>();
-                for (var config = this; config != null; config = config.Fallback?.Copy())
+                elements.AddRange(Value);
+
+                var config = this.Fallback?.Copy();
+                while (config != null)
                 {
-                    elements.AddRange(config.Value);
+                    elements.AddRange(config.Root);
+                    config = config.Fallback?.Copy();
                 }
 
                 var aggregated = new HoconValue(null);


### PR DESCRIPTION
Close #196

Basically instead of taking `config.Fallback.Value` we should use `config.Fallback.Root`, because `Root` is aware of fallback values, while `Value` is not.

@Aaronontheweb This is based on #197, so may need to merge that one first