### PR TITLE
added v1.3.2 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,10 @@
-#### 1.3.1 January 22 2020 ####
+#### 1.3.2 January 22 2020 ####
 **Bugfix release for HOCON v1.3.0**
 
-You can [see the full set of changes in the HOCON v1.3.1 milestone](https://github.com/akkadotnet/HOCON/milestone/4).
+Key changes include:
+
+* [Critical bugfix: Fallbacks are mutable during traversal](https://github.com/akkadotnet/HOCON/issues/193)
+* [Added HOCON Debugger tools](https://github.com/akkadotnet/HOCON/pull/192)
+* [Performance: Lookups on configs with fallback are performing merge and allocations each time](https://github.com/akkadotnet/HOCON/issues/195)
+
+You can [see the full set of changes in the HOCON v1.3.2 milestone](https://github.com/akkadotnet/HOCON/milestone/5).

--- a/src/common.props
+++ b/src/common.props
@@ -2,9 +2,13 @@
   <PropertyGroup>
     <Copyright>Copyright © 2014-2019 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.3.1</VersionPrefix>
+    <VersionPrefix>1.3.2</VersionPrefix>
     <PackageReleaseNotes>Bugfix release for HOCON v1.3.0**
-You can [see the full set of changes in the HOCON v1.3.1 milestone](https://github.com/akkadotnet/HOCON/milestone/4).</PackageReleaseNotes>
+Key changes include:
+[Critical bugfix: Fallbacks are mutable during traversal](https://github.com/akkadotnet/HOCON/issues/193)
+[Added HOCON Debugger tools](https://github.com/akkadotnet/HOCON/pull/192)
+[Performance: Lookups on configs with fallback are performing merge and allocations each time](https://github.com/akkadotnet/HOCON/issues/195)
+You can [see the full set of changes in the HOCON v1.3.2 milestone](https://github.com/akkadotnet/HOCON/milestone/5).</PackageReleaseNotes>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/HOCON</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/HOCON/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
#### 1.3.2 January 22 2020 ####
**Bugfix release for HOCON v1.3.0**

Key changes include:

* [Critical bugfix: Fallbacks are mutable during traversal](https://github.com/akkadotnet/HOCON/issues/193)
* [Added HOCON Debugger tools](https://github.com/akkadotnet/HOCON/pull/192)
* [Performance: Lookups on configs with fallback are performing merge and allocations each time](https://github.com/akkadotnet/HOCON/issues/195)

You can [see the full set of changes in the HOCON v1.3.2 milestone](https://github.com/akkadotnet/HOCON/milestone/5).