### PR TITLE
v1.3.2 Release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,10 @@
-#### 1.3.1 January 22 2020 ####
+#### 1.3.2 January 22 2020 ####
 **Bugfix release for HOCON v1.3.0**
 
-You can [see the full set of changes in the HOCON v1.3.1 milestone](https://github.com/akkadotnet/HOCON/milestone/4).
+Key changes include:
+
+* [Critical bugfix: Fallbacks are mutable during traversal](https://github.com/akkadotnet/HOCON/issues/193)
+* [Added HOCON Debugger tools](https://github.com/akkadotnet/HOCON/pull/192)
+* [Performance: Lookups on configs with fallback are performing merge and allocations each time](https://github.com/akkadotnet/HOCON/issues/195)
+
+You can [see the full set of changes in the HOCON v1.3.2 milestone](https://github.com/akkadotnet/HOCON/milestone/5).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-#### 1.3.2 January 22 2020 ####
+#### 1.3.2 January 24 2020 ####
 **Bugfix release for HOCON v1.3.0**
 
 Key changes include:

--- a/src/HOCON.Tests/QuotedString.cs
+++ b/src/HOCON.Tests/QuotedString.cs
@@ -1,0 +1,36 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="QuotedString.cs" company="Akka.NET Project">
+//      Copyright (C) 2013 - 2020 .NET Foundation <https://github.com/akkadotnet/hocon>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Hocon.Tests
+{
+    public class QuotedString
+    {
+        /// <summary>
+        /// Per https://github.com/akkadotnet/HOCON/issues/190
+        /// </summary>
+        [Fact(DisplayName = "Bugfix 190 - should unquoted quoted strings on parse")]
+        public void Bugfix_190_should_unquote_quotedstrings_on_parse()
+        {
+            var hocon = @"
+                adapters {
+                  gremlin = ""Akka.Remote.Transport.FailureInjectorProvider,Akka.Remote""
+                  trttl = ""Akka.Remote.Transport.ThrottlerProvider,Akka.Remote""
+                }
+            ";
+
+            var parsed = Parser.Parse(hocon);
+            var unwrapped = parsed.GetObject("adapters").ToDictionary(x => x.Key, v => v.Value.GetString());
+
+            // check to make sure these strings aren't quoted
+            unwrapped["gremlin"].Should().Be("Akka.Remote.Transport.FailureInjectorProvider,Akka.Remote");
+            unwrapped["trttl"].Should().Be("Akka.Remote.Transport.ThrottlerProvider,Akka.Remote");
+        }
+    }
+}

--- a/src/Hocon.Configuration.Test/DebuggerSpec.cs
+++ b/src/Hocon.Configuration.Test/DebuggerSpec.cs
@@ -99,7 +99,7 @@ namespace Hocon.Configuration.Tests
                 .SafeWithFallback(myHocon2)
                 .SafeWithFallback(myHocon3);
 
-            //fullHocon.GetString("akka.remote.transport").Should().Be("foo");
+            fullHocon.GetString("akka.remote.transport").Should().Be("foo");
 
             var dump = fullHocon.DumpConfig();
             dump.Should().Contain(myHocon1.PrettyPrint(2));

--- a/src/Hocon.Configuration.Test/DebuggerSpec.cs
+++ b/src/Hocon.Configuration.Test/DebuggerSpec.cs
@@ -1,0 +1,110 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="DebuggerSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2013 - 2020 .NET Foundation <https://github.com/akkadotnet/hocon>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using FluentAssertions;
+using Hocon.Debugger;
+using Xunit;
+
+namespace Hocon.Configuration.Tests
+{
+    public class DebuggerSpec
+    {
+        [Fact]
+        public void Should_dump_stand_alone_HOCON()
+        {
+            var myHocon = ConfigurationFactory.ParseString(@"akka{
+                actor.provider = cluster
+                deployment{
+                    /foo {
+                        dispatcher = bar
+                    }
+                }
+            }");
+
+            var dump = myHocon.DumpConfig();
+            dump.Should().Contain(myHocon.PrettyPrint(2));
+        }
+
+        [Fact]
+        public void Should_dump_HOCON_with_1_Fallback()
+        {
+            var myHocon1 = ConfigurationFactory.ParseString(@"akka{
+                actor.provider = cluster
+                deployment{
+                    /foo {
+                        dispatcher = bar
+                    }
+                }
+            }");
+
+            var myHocon2 = ConfigurationFactory.ParseString(@"akka{
+                debug{
+                    received  = on
+                }
+                actor.provider = cluster
+                deployment{
+                    /foo {
+                        dispatcher = foo
+                    }
+                    /bar {
+                        mailbox = ""myFoo""
+                    }
+                }
+            }");
+
+            var fullHocon = myHocon1.WithFallback(myHocon2);
+
+            var dump = fullHocon.DumpConfig();
+            dump.Should().Contain(myHocon1.PrettyPrint(2));
+            dump.Should().Contain(myHocon2.PrettyPrint(2));
+        }
+
+        [Fact]
+        public void Should_dump_HOCON_with_2_Fallback()
+        {
+            var myHocon1 = ConfigurationFactory.ParseString(@"akka{
+                actor.provider = cluster
+                deployment{
+                    /foo {
+                        dispatcher = bar
+                    }
+                }
+            }");
+
+            var myHocon2 = ConfigurationFactory.ParseString(@"akka{
+                debug{
+                    received  = on
+                }
+                actor.provider = cluster
+                deployment{
+                    /foo {
+                        dispatcher = foo
+                    }
+                    /bar {
+                        mailbox = ""myFoo""
+                    }
+                }
+            }");
+
+            var myHocon3 = ConfigurationFactory.ParseString(@"akka{
+                remote{
+                    transport = ""foo""
+                }
+            }");
+
+            var fullHocon = myHocon1
+                .SafeWithFallback(myHocon2)
+                .SafeWithFallback(myHocon3);
+
+            //fullHocon.GetString("akka.remote.transport").Should().Be("foo");
+
+            var dump = fullHocon.DumpConfig();
+            dump.Should().Contain(myHocon1.PrettyPrint(2));
+            dump.Should().Contain(myHocon2.PrettyPrint(2));
+            dump.Should().Contain(myHocon3.PrettyPrint(2));
+        }
+    }
+}

--- a/src/Hocon.Configuration/Config.cs
+++ b/src/Hocon.Configuration/Config.cs
@@ -18,22 +18,32 @@ namespace Hocon
     /// </summary>
     public class Config : HoconRoot
     {
+        [Obsolete("For json serialization/deserialization only", true)]
+        private Config()
+        {
+        }
+        
         /// <inheritdoc />
         /// <summary>
         ///     Initializes a new instance of the <see cref="Config" /> class.
         /// </summary>
-        private Config()
+        private Config(HoconValue value, Config fallback)
         {
+            Fallback = fallback;
+            Value = value;
+            
+            Root = GetRootValue();
         }
 
-        /// <inheritdoc cref="Config()" />
+        /// <inheritdoc cref="Config(HoconValue, Config)" />
         /// <param name="root">The root node to base this configuration.</param>
         /// <exception cref="T:System.ArgumentNullException">"The root value cannot be null."</exception>
         public Config(HoconRoot root) : base(root?.Value, root?.Substitutions ?? Enumerable.Empty<HoconSubstitution>())
         {
+            Root = GetRootValue();
         }
 
-        /// <inheritdoc cref="Config()" />
+        /// <inheritdoc cref="Config(HoconValue, Config)" />
         /// <param name="source">The configuration to use as the primary source.</param>
         /// <param name="fallback">The configuration to use as a secondary source.</param>
         /// <exception cref="ArgumentNullException">The source configuration cannot be null.</exception>
@@ -41,6 +51,8 @@ namespace Hocon
             source?.Substitutions ?? Enumerable.Empty<HoconSubstitution>())
         {
             Fallback = fallback;
+            
+            Root = GetRootValue();
         }
 
         /// <summary>
@@ -54,27 +66,12 @@ namespace Hocon
         /// <summary>
         ///     The configuration used as a secondary source.
         /// </summary>
-        public Config Fallback { get; private set; }
+        public Config Fallback { get; }
 
         /// <summary>
         ///     The root node of this configuration section
         /// </summary>
-        public virtual HoconValue Root
-        {
-            get
-            {
-                var elements = new List<IHoconElement>();
-                for (var config = this; config != null; config = config.Fallback?.Copy())
-                {
-                    elements.AddRange(config.Value);
-                }
-
-                var aggregated = new HoconValue(null);
-                aggregated.AddRange(elements.AsEnumerable().Reverse());
-
-                return aggregated;
-            }
-        }
+        public virtual HoconValue Root { get; }
 
         /// <summary>
         ///     Returns string representation of <see cref="Config" />, allowing to include fallback values
@@ -95,11 +92,7 @@ namespace Hocon
         protected Config Copy()
         {
             //deep clone
-            return new Config
-            {
-                Fallback = Fallback?.Copy(),
-                Value = (HoconValue) Value.Clone(null)
-            };
+            return new Config((HoconValue) Value.Clone(null), Fallback?.Copy());
         }
 
         protected override HoconValue GetNode(HoconPath path, bool throwIfNotFound = false)
@@ -144,14 +137,10 @@ namespace Hocon
         {
             if (fallback == this)
                 throw new ArgumentException("Config can not have itself as fallback", nameof(fallback));
-
-            var clone = Copy();
-
-            var current = clone;
-            while (current.Fallback != null) current = current.Fallback;
-            current.Fallback = fallback.Copy();
-
-            return clone;
+            
+            // If Fallback is not set - we will set it in new copy
+            // If Fallback was set - just use it, but with adding new fallback values
+            return new Config((HoconValue) Value.Clone(null), Fallback?.WithFallback(fallback) ?? fallback);
         }
 
         /// <summary>
@@ -198,6 +187,24 @@ namespace Hocon
                 yield return kvp;
                 used.Add(kvp.Key);
             }
+        }
+        
+        /// <summary>
+        /// Performs aggregation of Value and all Fallbacks into single <see cref="HoconValue"/> object
+        /// </summary>
+        private HoconValue GetRootValue()
+        {
+            var elements = new List<IHoconElement>();
+
+            for (var config = this; config != null; config = config.Fallback?.Copy())
+            {
+                elements.AddRange(config.Value);
+            }
+
+            var aggregated = new HoconValue(null);
+            aggregated.AddRange(elements.AsEnumerable().Reverse());
+
+            return aggregated;
         }
     }
 

--- a/src/Hocon.Configuration/Config.cs
+++ b/src/Hocon.Configuration/Config.cs
@@ -64,7 +64,7 @@ namespace Hocon
             get
             {
                 var elements = new List<IHoconElement>();
-                for (var config = this; config != null; config = config.Fallback)
+                for (var config = this; config != null; config = config.Fallback?.Copy())
                 {
                     elements.AddRange(config.Value);
                 }

--- a/src/Hocon.Configuration/ConfigurationFactory.cs
+++ b/src/Hocon.Configuration/ConfigurationFactory.cs
@@ -62,7 +62,7 @@ namespace Hocon
         [Obsolete("Call the ConfigurationFactory.Default method instead.")]
         public static Config Load()
         {
-            return Load("akka");
+            return Default();
         }
 
         /// <summary>

--- a/src/Hocon.Configuration/Debugger/DebuggingExtensions.cs
+++ b/src/Hocon.Configuration/Debugger/DebuggingExtensions.cs
@@ -1,0 +1,49 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="DebuggingExtensions.cs" company="Akka.NET Project">
+//      Copyright (C) 2013 - 2020 .NET Foundation <https://github.com/akkadotnet/hocon>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Text;
+
+
+namespace Hocon.Debugger
+{
+    /// <summary>
+    /// Debugging extensions for <see cref="Config"/> objects.
+    /// </summary>
+    public static class DebuggingExtensions
+    {
+        /// <summary>
+        /// Dumps all of the fallbacks in the order in which they would be resolved.
+        /// </summary>
+        /// <param name="c">The top-level config.</param>
+        /// <returns>A stringified list of fallbacks</returns>
+        public static string DumpConfig(this Config c)
+        {
+            var sb = new StringBuilder();
+            var hoconCount = 0;
+
+            void AppendHocon(Config config, int i)
+            {
+                sb.AppendFormat("HOCON{0}", i)
+                    .AppendLine()
+                    .Append(config.PrettyPrint(2))
+                    .AppendLine();
+            }
+
+            AppendHocon(c, hoconCount);
+
+            var current = c;
+            while (current.Fallback != null)
+            {
+                // add a header here
+                sb.AppendLine().AppendLine("------------");
+                current = current.Fallback;
+                AppendHocon(current, ++hoconCount);
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/Hocon/Impl/HoconField.cs
+++ b/src/Hocon/Impl/HoconField.cs
@@ -76,11 +76,13 @@ namespace Hocon
         /// <inheritdoc />
         public string Raw => Value.Raw;
 
+        /// <inheritdoc />
         public HoconObject GetObject()
         {
             return Value.GetObject();
         }
 
+        /// <inheritdoc />
         public string GetString()
         {
             return Value.GetString();

--- a/src/Hocon/Impl/IHoconElement.cs
+++ b/src/Hocon/Impl/IHoconElement.cs
@@ -31,6 +31,10 @@ namespace Hocon
         ///     Retrieves the string representation of this element.
         /// </summary>
         /// <returns>The string representation of this element.</returns>
+        /// <remarks>
+        /// NOTE: this returns an unquoted string. If you want the raw, underlying string
+        /// including quotes call <see cref="object.ToString()"/> instead.
+        /// </remarks>
         string GetString();
 
         /// <summary>

--- a/src/common.props
+++ b/src/common.props
@@ -2,9 +2,13 @@
   <PropertyGroup>
     <Copyright>Copyright © 2014-2019 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.3.1</VersionPrefix>
+    <VersionPrefix>1.3.2</VersionPrefix>
     <PackageReleaseNotes>Bugfix release for HOCON v1.3.0**
-You can [see the full set of changes in the HOCON v1.3.1 milestone](https://github.com/akkadotnet/HOCON/milestone/4).</PackageReleaseNotes>
+Key changes include:
+[Critical bugfix: Fallbacks are mutable during traversal](https://github.com/akkadotnet/HOCON/issues/193)
+[Added HOCON Debugger tools](https://github.com/akkadotnet/HOCON/pull/192)
+[Performance: Lookups on configs with fallback are performing merge and allocations each time](https://github.com/akkadotnet/HOCON/issues/195)
+You can [see the full set of changes in the HOCON v1.3.2 milestone](https://github.com/akkadotnet/HOCON/milestone/5).</PackageReleaseNotes>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/HOCON</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/HOCON/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
#### 1.3.2 January 24 2020 ####
**Bugfix release for HOCON v1.3.0**

Key changes include:

* [Critical bugfix: Fallbacks are mutable during traversal](https://github.com/akkadotnet/HOCON/issues/193)
* [Added HOCON Debugger tools](https://github.com/akkadotnet/HOCON/pull/192)
* [Performance: Lookups on configs with fallback are performing merge and allocations each time](https://github.com/akkadotnet/HOCON/issues/195)

You can [see the full set of changes in the HOCON v1.3.2 milestone](https://github.com/akkadotnet/HOCON/milestone/5).