### PR TITLE
added v1.3.3 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,9 @@
-#### 1.3.2 January 24 2020 ####
+#### 1.3.3 January 27 2020 ####
 **Bugfix release for HOCON v1.3.0**
 
 Key changes include:
 
-* [Critical bugfix: Fallbacks are mutable during traversal](https://github.com/akkadotnet/HOCON/issues/193)
-* [Added HOCON Debugger tools](https://github.com/akkadotnet/HOCON/pull/192)
-* [Performance: Lookups on configs with fallback are performing merge and allocations each time](https://github.com/akkadotnet/HOCON/issues/195)
+* [Make `Config` implement `ISerializable`](https://github.com/akkadotnet/HOCON/pull/207)
+* [Implement Akka.NET backwards compatibility fixes](https://github.com/akkadotnet/HOCON/pull/204)
 
-You can [see the full set of changes in the HOCON v1.3.2 milestone](https://github.com/akkadotnet/HOCON/milestone/5).
+You can [see the full set of changes in the HOCON v1.3.3 milestone](https://github.com/akkadotnet/HOCON/milestone/6).

--- a/src/common.props
+++ b/src/common.props
@@ -2,13 +2,12 @@
   <PropertyGroup>
     <Copyright>Copyright © 2014-2019 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.3.2</VersionPrefix>
+    <VersionPrefix>1.3.3</VersionPrefix>
     <PackageReleaseNotes>Bugfix release for HOCON v1.3.0**
 Key changes include:
-[Critical bugfix: Fallbacks are mutable during traversal](https://github.com/akkadotnet/HOCON/issues/193)
-[Added HOCON Debugger tools](https://github.com/akkadotnet/HOCON/pull/192)
-[Performance: Lookups on configs with fallback are performing merge and allocations each time](https://github.com/akkadotnet/HOCON/issues/195)
-You can [see the full set of changes in the HOCON v1.3.2 milestone](https://github.com/akkadotnet/HOCON/milestone/5).</PackageReleaseNotes>
+[Make `Config` implement `ISerializable`](https://github.com/akkadotnet/HOCON/pull/207)
+[Implement Akka.NET backwards compatibility fixes](https://github.com/akkadotnet/HOCON/pull/204)
+You can [see the full set of changes in the HOCON v1.3.3 milestone](https://github.com/akkadotnet/HOCON/milestone/6).</PackageReleaseNotes>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/HOCON</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/HOCON/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
#### 1.3.3 January 27 2020 ####
**Bugfix release for HOCON v1.3.0**

Key changes include:

* [Make `Config` implement `ISerializable`](https://github.com/akkadotnet/HOCON/pull/207)
* [Implement Akka.NET backwards compatibility fixes](https://github.com/akkadotnet/HOCON/pull/204)

You can [see the full set of changes in the HOCON v1.3.3 milestone](https://github.com/akkadotnet/HOCON/milestone/6).