### PR TITLE
Hocon improvement.

### DIFF
--- a/src/Hocon.Configuration.Test/ConfigurationSpec.cs
+++ b/src/Hocon.Configuration.Test/ConfigurationSpec.cs
@@ -594,7 +594,7 @@ foo {
             a.WithFallback(b);
 
             a.Fallbacks.Count.Should().Be(0);
-            a.GetString("akka.other-key").Should().BeNull();
+            a.GetString("akka.other-key", null).Should().BeNull();
             ReferenceEquals(oldA, a).Should().BeTrue();
             oldAContent.Should().Equals(a);
         }

--- a/src/Hocon.Configuration/Config.cs
+++ b/src/Hocon.Configuration/Config.cs
@@ -18,7 +18,7 @@ namespace Hocon
     ///     configuration string.
     /// </summary>
     [Serializable]
-    public class Config : HoconRoot, ISerializable
+    public class Config : HoconRoot, ISerializable, IEquatable<Config>
     {
         private static readonly HoconValue EmptyValue;
 
@@ -265,6 +265,22 @@ namespace Hocon
         public void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             info.AddValue(SerializedPropertyName, ToString(useFallbackValues: true), typeof(string));
+        }
+
+        public bool Equals(Config other)
+        {
+            if (IsEmpty && other.IsEmpty) return true;
+            if (Value == other.Value) return true;
+            return false;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj is Config cfg)
+                return Equals(obj);
+            return false;
         }
 
         [Obsolete("Used for serialization only", true)]

--- a/src/Hocon.Configuration/Config.cs
+++ b/src/Hocon.Configuration/Config.cs
@@ -156,7 +156,7 @@ namespace Hocon
                     return returnValue;
             }
 
-            throw new HoconException($"Could not find accessible field at path {path} in all fallbacks.");
+            throw new HoconException($"Could not find accessible field at path `{path}` in all fallbacks.");
         }
 
         /// <summary>

--- a/src/Hocon.Configuration/ConfigurationException.cs
+++ b/src/Hocon.Configuration/ConfigurationException.cs
@@ -14,6 +14,13 @@ namespace Hocon
     /// </summary>
     public class ConfigurationException : Exception
     {
+        public static ConfigurationException NullOrEmptyConfig<T>(string path = null)
+        {
+            if (!string.IsNullOrWhiteSpace(path))
+                return new ConfigurationException($"Failed to instantiate {typeof(T).Name}: Configuration does not contain `{path}` node");
+            return new ConfigurationException($"Failed to instantiate {typeof(T).Name}: Configuration is null or empty.");
+        }
+
         /// <summary>
         ///     Initializes a new instance of the <see cref="ConfigurationException" /> class.
         /// </summary>

--- a/src/Hocon.Configuration/HoconConfigurationSection.cs
+++ b/src/Hocon.Configuration/HoconConfigurationSection.cs
@@ -33,7 +33,14 @@ namespace Hocon
         ///     Retrieves a <see cref="Config" /> from the contents of the
         ///     custom akka node within a configuration file.
         /// </summary>
-        public Config Config => _config ?? (_config = ConfigurationFactory.ParseString(Hocon.Content));
+        public Config Config {
+            get
+            {
+                if (_config == null && !string.IsNullOrWhiteSpace(Hocon.Content))
+                    _config = ConfigurationFactory.ParseString(Hocon.Content);
+                return _config;
+            }
+        }
 
         /// <summary>
         ///     Retrieves the HOCON (Human-Optimized Config Object Notation)

--- a/src/Hocon.Tests/HoconTests.cs
+++ b/src/Hocon.Tests/HoconTests.cs
@@ -377,45 +377,49 @@ A {
             var emptyConfig = HoconParser.Parse("{}");
             var missingKey = "a";
 
-            emptyConfig.GetInt(missingKey).Should().Be(0);
-            emptyConfig.GetDouble(missingKey).Should().Be(0);
+            emptyConfig.GetInt(missingKey, 0).Should().Be(0);
+            emptyConfig.GetDouble(missingKey, 0).Should().Be(0);
 
             emptyConfig.GetBooleanList(missingKey, new List<bool>()).Should().Equal(new List<bool>());
             emptyConfig.Invoking(c => c.GetBooleanList(missingKey)).Should().Throw<HoconValueException>().Which
-                .InnerException.Should().BeOfType<HoconParserException>();
+                .InnerException.Should().BeOfType<KeyNotFoundException>();
 
             emptyConfig.GetByteList(missingKey, new List<byte>()).Should().Equal(new List<byte>());
             emptyConfig.Invoking(c => c.GetByteList(missingKey)).Should().Throw<HoconValueException>().Which
-                .InnerException.Should().BeOfType<HoconParserException>();
+                .InnerException.Should().BeOfType<KeyNotFoundException>();
 
             emptyConfig.GetDecimalList(missingKey, new List<decimal>()).Should().Equal(new List<decimal>());
             emptyConfig.Invoking(c => c.GetDecimalList(missingKey)).Should().Throw<HoconValueException>().Which
-                .InnerException.Should().BeOfType<HoconParserException>();
+                .InnerException.Should().BeOfType<KeyNotFoundException>();
 
             emptyConfig.GetDoubleList(missingKey, new List<double>()).Should().Equal(new List<double>());
             emptyConfig.Invoking(c => c.GetDoubleList(missingKey)).Should().Throw<HoconValueException>().Which
-                .InnerException.Should().BeOfType<HoconParserException>();
+                .InnerException.Should().BeOfType<KeyNotFoundException>();
 
             emptyConfig.GetFloatList(missingKey, new List<float>()).Should().Equal(new List<float>());
             emptyConfig.Invoking(c => c.GetFloatList(missingKey)).Should().Throw<HoconValueException>().Which
-                .InnerException.Should().BeOfType<HoconParserException>();
+                .InnerException.Should().BeOfType<KeyNotFoundException>();
 
             emptyConfig.GetIntList(missingKey, new List<int>()).Should().Equal(new List<int>());
             emptyConfig.Invoking(c => c.GetIntList(missingKey)).Should().Throw<HoconValueException>().Which
-                .InnerException.Should().BeOfType<HoconParserException>();
+                .InnerException.Should().BeOfType<KeyNotFoundException>();
 
             emptyConfig.GetLongList(missingKey, new List<long>()).Should().Equal(new List<long>());
             emptyConfig.Invoking(c => c.GetLongList(missingKey)).Should().Throw<HoconValueException>().Which
-                .InnerException.Should().BeOfType<HoconParserException>();
+                .InnerException.Should().BeOfType<KeyNotFoundException>();
 
             emptyConfig.GetObjectList(missingKey, new List<HoconObject>()).Should().Equal(new List<HoconObject>());
             emptyConfig.Invoking(c => c.GetObjectList(missingKey)).Should().Throw<HoconValueException>().Which
-                .InnerException.Should().BeOfType<HoconParserException>();
+                .InnerException.Should().BeOfType<KeyNotFoundException>();
 
             emptyConfig.GetStringList(missingKey, new List<string>()).Should().Equal(new List<string>());
-            
+            emptyConfig.Invoking(c => c.GetStringList(missingKey)).Should().Throw<HoconValueException>().Which
+                .InnerException.Should().BeOfType<KeyNotFoundException>();
+
+            /*
             emptyConfig.Invoking(c => c.GetStringList(missingKey)).Should().NotThrow("String list is an exception of the rule")
                 .And.Subject().Should().BeEquivalentTo(new List<string>());
+            */
         }
 
         [Fact]
@@ -710,7 +714,7 @@ b {
         }
 
         [Fact]
-        public void GettingArrayFromLiteralsReturnsNull()
+        public void GettingArrayFromLiteralsShouldThrow()
         {
             var hocon = " literal : a b c";
             HoconParser.Parse(hocon).Invoking(c => c.GetStringList("literal")).Should()
@@ -718,10 +722,12 @@ b {
         }
 
         [Fact]
-        public void GettingStringFromArrayReturnsNull()
+        public void GettingStringFromArrayShouldThrow()
         {
             var hocon = " array : [1,2,3]";
-            Assert.Null(HoconParser.Parse(hocon).GetString("array"));
+            HoconParser.Parse(hocon).Invoking(c => c.GetStringList("literal")).Should()
+                .Throw<HoconException>("Anything converted to array should throw instead");
+            //Assert.Null(HoconParser.Parse(hocon).GetString("array"));
         }
 
         [Fact]

--- a/src/Hocon/HoconRoot.cs
+++ b/src/Hocon/HoconRoot.cs
@@ -252,13 +252,11 @@ namespace Hocon
         /// </summary>
         /// <param name="path">The path that contains the value to retrieve.</param>
         /// <returns>The string value defined in the specified path.</returns>
-        [Obsolete("Check for default value")]
         public virtual string GetString(string path)
         {
             return WrapWithValueException(path, () => GetNode(path).GetString());
         }
 
-        [Obsolete("Check for default value")]
         public virtual string GetString(HoconPath path)
         {
             return WrapWithValueException(path, () => GetNode(path).GetString());
@@ -331,13 +329,32 @@ namespace Hocon
         /// <returns>The long value defined in the specified path, or null if path was not found.</returns>
         public virtual long? GetByteSize(string path)
         {
-            return GetByteSize(HoconPath.Parse(path));
+            return WrapWithValueException(path, () => GetNode(path).GetByteSize());
         }
 
         /// <inheritdoc cref="GetByteSize(string)" />
         public virtual long? GetByteSize(HoconPath path)
         {
-            return WrapWithValueException(path.ToString(), () => GetNode(path).GetByteSize());
+            return WrapWithValueException(path, () => GetNode(path).GetByteSize());
+        }
+
+        public virtual long? GetByteSize(string path, long? @default)
+        {
+            if (TryGetNode(path, out var value))
+                if (value.TryGetByteSize(out var longValue))
+                    return longValue;
+
+            return null;
+        }
+
+        /// <inheritdoc cref="GetByteSize(string)" />
+        public virtual long? GetByteSize(HoconPath path, long? @default)
+        {
+            if (TryGetNode(path, out var value))
+                if (value.TryGetByteSize(out var longValue))
+                    return longValue;
+
+            return null;
         }
 
         /// <summary>
@@ -345,13 +362,11 @@ namespace Hocon
         /// </summary>
         /// <param name="path">The path that contains the value to retrieve.</param>
         /// <returns>The integer value defined in the specified path.</returns>
-        [Obsolete("Check for default value")]
         public virtual int GetInt(string path)
         {
             return WrapWithValueException(path, () => GetNode(path).GetInt());
         }
 
-        [Obsolete("Check for default value")]
         public virtual int GetInt(HoconPath path)
         {
             return WrapWithValueException(path, () => GetNode(path).GetInt());
@@ -522,13 +537,11 @@ namespace Hocon
             return @default;
         }
 
-        [Obsolete("Check for default value")]
         public virtual double GetDouble(string path)
         {
             return WrapWithValueException(path, () => GetNode(path).GetDouble());
         }
 
-        [Obsolete("Check for default value")]
         public virtual double GetDouble(HoconPath path)
         {
             return WrapWithValueException(path, () => GetNode(path).GetDouble());

--- a/src/Hocon/HoconRoot.cs
+++ b/src/Hocon/HoconRoot.cs
@@ -123,8 +123,6 @@ namespace Hocon
 
         private static void Flatten(IHoconElement node)
         {
-            if (node is HoconSubstitution sub)
-                node = sub.ResolvedValue;
 
             if (!(node is HoconValue v))
                 return;
@@ -900,13 +898,11 @@ namespace Hocon
         /// </summary>
         /// <param name="path">The path that contains the values to retrieve.</param>
         /// <returns>The list of string values defined in the specified path.</returns>
-        [Obsolete("Check for default value")]
         public virtual IList<string> GetStringList(string path)
         {
             return WrapWithValueException(path, () => GetNode(path).GetStringList() ?? new List<string>());
         }
 
-        [Obsolete("Check for default value")]
         public virtual IList<string> GetStringList(HoconPath path)
         {
             return WrapWithValueException(path, () => GetNode(path).GetStringList() ?? new List<string>());

--- a/src/Hocon/HoconRoot.cs
+++ b/src/Hocon/HoconRoot.cs
@@ -54,22 +54,38 @@ namespace Hocon
         /// </summary>
         public IEnumerable<HoconSubstitution> Substitutions { get; private set; }
 
-        protected virtual HoconValue GetNode(HoconPath path, bool throwIfNotFound = false)
+        protected virtual bool TryGetNode(string path, out HoconValue result)
+        {
+            result = null;
+            if (!HoconPath.TryParse(path, out var hoconPath))
+                return false;
+            return TryGetNode(hoconPath, out result);
+        }
+
+        protected virtual bool TryGetNode(HoconPath path, out HoconValue result)
+        {
+            result = null;
+            if (Value.Type != HoconType.Object)
+                return false;
+
+            var obj = Value.GetObject();
+            if (obj == null)
+                return false;
+
+            return obj.TryGetValue(path, out result);
+        }
+
+        protected virtual HoconValue GetNode(string path)
+        {
+            return GetNode(HoconPath.Parse(path));
+        }
+
+        protected virtual HoconValue GetNode(HoconPath path)
         {
             if (Value.Type != HoconType.Object)
                 throw new HoconException("Hocon is not an object.");
 
-            try
-            {
-                return Value.GetObject().GetValue(path);
-            }
-            catch (KeyNotFoundException)
-            {
-                if (throwIfNotFound)
-                    throw;
-
-                return null;
-            }
+            return Value.GetObject().GetValue(path);
         }
 
         /// <summary>
@@ -89,17 +105,7 @@ namespace Hocon
         /// <returns><c>true</c> if a value was found, <c>false</c> otherwise.</returns>
         public virtual bool HasPath(HoconPath path)
         {
-            HoconValue node;
-            try
-            {
-                node = GetNode(path);
-            }
-            catch
-            {
-                return false;
-            }
-
-            return node != null;
+            return TryGetNode(path, out var _);
         }
 
 
@@ -214,6 +220,18 @@ namespace Hocon
             }
         }
 
+        protected T WrapWithValueException<T>(HoconPath path, Func<T> func)
+        {
+            try
+            {
+                return func();
+            }
+            catch (Exception ex)
+            {
+                throw new HoconValueException(ex.Message, path.ToString(), ex);
+            }
+        }
+
         public bool Equals(HoconRoot other)
         {
             return Value == other.Value;
@@ -228,25 +246,57 @@ namespace Hocon
 
         #region Value getter methods
 
+        #region Single value getters
+        /// <summary>
+        ///     Retrieves a string value from the specified path in the configuration.
+        /// </summary>
+        /// <param name="path">The path that contains the value to retrieve.</param>
+        /// <returns>The string value defined in the specified path.</returns>
+        [Obsolete("Check for default value")]
+        public virtual string GetString(string path)
+        {
+            return WrapWithValueException(path, () => GetNode(path).GetString());
+        }
+
+        [Obsolete("Check for default value")]
+        public virtual string GetString(HoconPath path)
+        {
+            return WrapWithValueException(path, () => GetNode(path).GetString());
+        }
+
         /// <summary>
         ///     Retrieves a string value from the specified path in the configuration.
         /// </summary>
         /// <param name="path">The path that contains the value to retrieve.</param>
         /// <param name="default">The default value to return if the value doesn't exist.</param>
         /// <returns>The string value defined in the specified path.</returns>
-        public virtual string GetString(string path, string @default = null)
+        public virtual string GetString(string path, string @default)
         {
-            return WrapWithValueException(path, () => GetString(HoconPath.Parse(path), @default));
+            if (TryGetNode(path, out var value))
+                if (value.TryGetString(out var result))
+                    return result;
+
+            return @default;
         }
 
         /// <inheritdoc cref="GetString(string,string)" />
-        public virtual string GetString(HoconPath path, string @default = null)
+        public virtual string GetString(HoconPath path, string @default)
         {
-            return WrapWithValueException(path.ToString(), () =>
-            {
-                var value = GetNode(path);
-                return value == null ? @default : value.GetString();
-            });
+            if (TryGetNode(path, out var value))
+                if (value.TryGetString(out var result))
+                    return result;
+
+            return @default;
+        }
+
+        public virtual bool GetBoolean(string path)
+        {
+            return WrapWithValueException(path, () => GetNode(path).GetBoolean());
+        }
+
+        public virtual bool GetBoolean(HoconPath path)
+        {
+            return WrapWithValueException(path, () => GetNode(path).GetBoolean());
         }
 
         /// <summary>
@@ -255,19 +305,23 @@ namespace Hocon
         /// <param name="path">The path that contains the value to retrieve.</param>
         /// <param name="default">The default value to return if the value doesn't exist.</param>
         /// <returns>The boolean value defined in the specified path.</returns>
-        public virtual bool GetBoolean(string path, bool @default = false)
+        public virtual bool GetBoolean(string path, bool @default)
         {
-            return WrapWithValueException(path, () => GetBoolean(HoconPath.Parse(path), @default));
+            if (TryGetNode(path, out var value))
+                if (value.TryGetBoolean(out var result))
+                    return result;
+
+            return @default;
         }
 
         /// <inheritdoc cref="GetBoolean(string,bool)" />
-        public virtual bool GetBoolean(HoconPath path, bool @default = false)
+        public virtual bool GetBoolean(HoconPath path, bool @default)
         {
-            return WrapWithValueException(path.ToString(), () =>
-            {
-                var value = GetNode(path);
-                return value == null ? @default : value.GetBoolean();
-            });
+            if (TryGetNode(path, out var value))
+                if (value.TryGetBoolean(out var result))
+                    return result;
+
+            return @default;
         }
 
         /// <summary>
@@ -277,17 +331,30 @@ namespace Hocon
         /// <returns>The long value defined in the specified path, or null if path was not found.</returns>
         public virtual long? GetByteSize(string path)
         {
-            return WrapWithValueException(path, () => GetByteSize(HoconPath.Parse(path)));
+            return GetByteSize(HoconPath.Parse(path));
         }
 
         /// <inheritdoc cref="GetByteSize(string)" />
         public virtual long? GetByteSize(HoconPath path)
         {
-            return WrapWithValueException(path.ToString(), () =>
-            {
-                var value = GetNode(path);
-                return value?.GetByteSize();
-            });
+            return WrapWithValueException(path.ToString(), () => GetNode(path).GetByteSize());
+        }
+
+        /// <summary>
+        ///     Retrieves an integer value from the specified path in the configuration.
+        /// </summary>
+        /// <param name="path">The path that contains the value to retrieve.</param>
+        /// <returns>The integer value defined in the specified path.</returns>
+        [Obsolete("Check for default value")]
+        public virtual int GetInt(string path)
+        {
+            return WrapWithValueException(path, () => GetNode(path).GetInt());
+        }
+
+        [Obsolete("Check for default value")]
+        public virtual int GetInt(HoconPath path)
+        {
+            return WrapWithValueException(path, () => GetNode(path).GetInt());
         }
 
         /// <summary>
@@ -296,19 +363,33 @@ namespace Hocon
         /// <param name="path">The path that contains the value to retrieve.</param>
         /// <param name="default">The default value to return if the value doesn't exist.</param>
         /// <returns>The integer value defined in the specified path.</returns>
-        public virtual int GetInt(string path, int @default = 0)
+        public virtual int GetInt(string path, int @default)
         {
-            return WrapWithValueException(path, () => GetInt(HoconPath.Parse(path), @default));
+            if (TryGetNode(path, out var value))
+                if (value.TryGetInt(out var result))
+                    return result;
+
+            return @default;
         }
 
         /// <inheritdoc cref="GetInt(string,int)" />
-        public virtual int GetInt(HoconPath path, int @default = 0)
+        public virtual int GetInt(HoconPath path, int @default)
         {
-            return WrapWithValueException(path.ToString(), () =>
-            {
-                var value = GetNode(path);
-                return value == null ? @default : value.GetInt();
-            });
+            if (TryGetNode(path, out var value))
+                if (value.TryGetInt(out var result))
+                    return result;
+
+            return @default;
+        }
+
+        public virtual long GetLong(string path)
+        {
+            return WrapWithValueException(path, () => GetNode(HoconPath.Parse(path)).GetLong());
+        }
+
+        public virtual long GetLong(HoconPath path)
+        {
+            return WrapWithValueException(path, () => GetNode(path).GetLong());
         }
 
         /// <summary>
@@ -317,19 +398,33 @@ namespace Hocon
         /// <param name="path">The path that contains the value to retrieve.</param>
         /// <param name="default">The default value to return if the value doesn't exist.</param>
         /// <returns>The long value defined in the specified path.</returns>
-        public virtual long GetLong(string path, long @default = 0)
+        public virtual long GetLong(string path, long @default)
         {
-            return WrapWithValueException(path, () => GetLong(HoconPath.Parse(path), @default));
+            if (TryGetNode(path, out var value))
+                if (value.TryGetLong(out var result))
+                    return result;
+
+            return @default;
         }
 
         /// <inheritdoc cref="GetLong(string,long)" />
         public virtual long GetLong(HoconPath path, long @default = 0)
         {
-            return WrapWithValueException(path.ToString(), () =>
-            {
-                var value = GetNode(path);
-                return value == null ? @default : value.GetLong();
-            });
+            if (TryGetNode(path, out var value))
+                if (value.TryGetLong(out var result))
+                    return result;
+
+            return @default;
+        }
+
+        public virtual byte GetByte(string path)
+        {
+            return WrapWithValueException(path, () => GetNode(path).GetByte());
+        }
+
+        public virtual byte GetByte(HoconPath path)
+        {
+            return WrapWithValueException(path, () => GetNode(path).GetByte());
         }
 
         /// <summary>
@@ -338,19 +433,33 @@ namespace Hocon
         /// <param name="path">The path that contains the value to retrieve.</param>
         /// <param name="default">The default value to return if the value doesn't exist.</param>
         /// <returns>The byte value defined in the specified path.</returns>
-        public virtual byte GetByte(string path, byte @default = 0)
+        public virtual byte GetByte(string path, byte @default)
         {
-            return WrapWithValueException(path, () => GetByte(HoconPath.Parse(path), @default));
+            if (TryGetNode(path, out var value))
+                if (value.TryGetByte(out var result))
+                    return result;
+
+            return @default;
         }
 
         /// <inheritdoc cref="GetByte(string,byte)" />
         public virtual byte GetByte(HoconPath path, byte @default = 0)
         {
-            return WrapWithValueException(path.ToString(), () =>
-            {
-                var value = GetNode(path);
-                return value == null ? @default : value.GetByte();
-            });
+            if (TryGetNode(path, out var value))
+                if (value.TryGetByte(out var result))
+                    return result;
+
+            return @default;
+        }
+
+        public virtual float GetFloat(string path)
+        {
+            return WrapWithValueException(path, () => GetNode(path).GetFloat());
+        }
+
+        public virtual float GetFloat(HoconPath path)
+        {
+            return WrapWithValueException(path, () => GetNode(path).GetFloat());
         }
 
         /// <summary>
@@ -359,19 +468,33 @@ namespace Hocon
         /// <param name="path">The path that contains the value to retrieve.</param>
         /// <param name="default">The default value to return if the value doesn't exist.</param>
         /// <returns>The float value defined in the specified path.</returns>
-        public virtual float GetFloat(string path, float @default = 0)
+        public virtual float GetFloat(string path, float @default)
         {
-            return WrapWithValueException(path, () => GetFloat(HoconPath.Parse(path), @default));
+            if (TryGetNode(path, out var value))
+                if (value.TryGetFloat(out var result))
+                    return result;
+
+            return @default;
         }
 
         /// <inheritdoc cref="GetFloat(string,float)" />
         public virtual float GetFloat(HoconPath path, float @default = 0)
         {
-            return WrapWithValueException(path.ToString(), () =>
-            {
-                var value = GetNode(path);
-                return value == null ? @default : value.GetFloat();
-            });
+            if (TryGetNode(path, out var value))
+                if (value.TryGetFloat(out var result))
+                    return result;
+
+            return @default;
+        }
+
+        public virtual decimal GetDecimal(string path)
+        {
+            return WrapWithValueException(path, () => GetNode(path).GetDecimal());
+        }
+
+        public virtual decimal GetDecimal(HoconPath path)
+        {
+            return WrapWithValueException(path, () => GetNode(path).GetDecimal());
         }
 
         /// <summary>
@@ -380,19 +503,35 @@ namespace Hocon
         /// <param name="path">The path that contains the value to retrieve.</param>
         /// <param name="default">The default value to return if the value doesn't exist.</param>
         /// <returns>The decimal value defined in the specified path.</returns>
-        public virtual decimal GetDecimal(string path, decimal @default = 0)
+        public virtual decimal GetDecimal(string path, decimal @default)
         {
-            return WrapWithValueException(path, () => GetDecimal(HoconPath.Parse(path), @default));
+            if (TryGetNode(path, out var value))
+                if (value.TryGetDecimal(out var result))
+                    return result;
+
+            return @default;
         }
 
         /// <inheritdoc cref="GetDecimal(string,decimal)" />
-        public virtual decimal GetDecimal(HoconPath path, decimal @default = 0)
+        public virtual decimal GetDecimal(HoconPath path, decimal @default)
         {
-            return WrapWithValueException(path.ToString(), () =>
-            {
-                var value = GetNode(path);
-                return value == null ? @default : value.GetDecimal();
-            });
+            if (TryGetNode(path, out var value))
+                if (value.TryGetDecimal(out var result))
+                    return result;
+
+            return @default;
+        }
+
+        [Obsolete("Check for default value")]
+        public virtual double GetDouble(string path)
+        {
+            return WrapWithValueException(path, () => GetNode(path).GetDouble());
+        }
+
+        [Obsolete("Check for default value")]
+        public virtual double GetDouble(HoconPath path)
+        {
+            return WrapWithValueException(path, () => GetNode(path).GetDouble());
         }
 
         /// <summary>
@@ -401,19 +540,33 @@ namespace Hocon
         /// <param name="path">The path that contains the value to retrieve.</param>
         /// <param name="default">The default value to return if the value doesn't exist.</param>
         /// <returns>The double value defined in the specified path.</returns>
-        public virtual double GetDouble(string path, double @default = 0)
+        public virtual double GetDouble(string path, double @default)
         {
-            return WrapWithValueException(path, () => GetDouble(HoconPath.Parse(path), @default));
+            if (TryGetNode(path, out var value))
+                if (value.TryGetDouble(out var result))
+                    return result;
+
+            return @default;
         }
 
         /// <inheritdoc cref="GetDouble(string,double)" />
-        public virtual double GetDouble(HoconPath path, double @default = 0)
+        public virtual double GetDouble(HoconPath path, double @default)
         {
-            return WrapWithValueException(path.ToString(), () =>
-            {
-                var value = GetNode(path);
-                return value == null ? @default : value.GetDouble();
-            });
+            if (TryGetNode(path, out var value))
+                if (value.TryGetDouble(out var result))
+                    return result;
+
+            return @default;
+        }
+
+        public virtual HoconObject GetObject(string path)
+        {
+            return WrapWithValueException(path, () => GetNode(path).GetObject());
+        }
+
+        public virtual HoconObject GetObject(HoconPath path)
+        {
+            return WrapWithValueException(path, () => GetNode(path).GetObject());
         }
 
         /// <summary>
@@ -422,21 +575,27 @@ namespace Hocon
         /// <param name="path">The path that contains the value to retrieve.</param>
         /// <param name="default">The default value to return if the value doesn't exist.</param>
         /// <returns>The double value defined in the specified path.</returns>
-        public virtual HoconObject GetObject(string path, HoconObject @default = null)
+        public virtual HoconObject GetObject(string path, HoconObject @default)
         {
-            return WrapWithValueException(path, () => GetObject(HoconPath.Parse(path), @default));
+            if (TryGetNode(path, out var value))
+                if (value.TryGetObject(out var result))
+                    return result;
+
+            return @default;
         }
 
         /// <inheritdoc cref="GetObject(string,HoconObject)" />
         public virtual HoconObject GetObject(HoconPath path, HoconObject @default = null)
         {
-            return WrapWithValueException(path.ToString(), () =>
-            {
-                var value = GetNode(path);
-                return value == null ? @default : value.GetObject();
-            });
-        }
+            if (TryGetNode(path, out var value))
+                if (value.TryGetObject(out var result))
+                    return result;
 
+            return @default;
+        }
+        #endregion
+
+        #region Array value getters
         /// <summary>
         ///     Retrieves a list of boolean values from the specified path in the configuration.
         /// </summary>
@@ -445,30 +604,36 @@ namespace Hocon
         /// <exception cref="HoconParserException">Thrown if path does not exist</exception>
         public virtual IList<bool> GetBooleanList(string path)
         {
-            return WrapWithValueException(path,
-                () => GetBooleanList(HoconPath.Parse(path)) ??
-                      throw new HoconParserException($"Hocon path {path} does not exist."));
+            return WrapWithValueException(path, () => { return GetNode(path).GetBooleanList(); });
         }
 
-        /// <summary>
-        ///     Retrieves a list of boolean values from the specified path in the configuration.
-        /// </summary>
-        /// <param name="path">The path that contains the values to retrieve.</param>
-        /// <param name="default">The default value to return if the value doesn't exist.</param>
-        /// <returns>The list of boolean values defined in the specified path.</returns>
-        public virtual IList<bool> GetBooleanList(string path, IList<bool> @default)
+        public virtual IList<bool> GetBooleanList(HoconPath path)
         {
-            return WrapWithValueException(path, () => GetBooleanList(HoconPath.Parse(path), @default));
+            return WrapWithValueException(path, () => { return GetNode(path).GetBooleanList(); });
         }
 
         /// <inheritdoc cref="GetBooleanList(string)" />
-        public virtual IList<bool> GetBooleanList(HoconPath path, IList<bool> @default = null)
+        /// <param name="path">The path that contains the values to retrieve.</param>
+        /// <param name="default">The default value to return if the value doesn't exist.</param>
+        public virtual IList<bool> GetBooleanList(string path, IList<bool> @default)
         {
-            return WrapWithValueException(path.ToString(), () =>
-            {
-                var value = GetNode(path);
-                return value == null ? @default : value.GetBooleanList();
-            });
+            if (TryGetNode(path, out var value))
+                if (value.TryGetBooleanList(out var result))
+                    return result;
+
+            return @default;
+        }
+
+        /// <inheritdoc cref="GetBooleanList(string)" />
+        /// <param name="path">The path that contains the values to retrieve.</param>
+        /// <param name="default">The default value to return if the value doesn't exist.</param>
+        public virtual IList<bool> GetBooleanList(HoconPath path, IList<bool> @default)
+        {
+            if (TryGetNode(path, out var value))
+                if (value.TryGetBooleanList(out var result))
+                    return result;
+
+            return @default;
         }
 
         /// <summary>
@@ -479,9 +644,12 @@ namespace Hocon
         /// <exception cref="HoconParserException">Thrown if path does not exist</exception>
         public virtual IList<decimal> GetDecimalList(string path)
         {
-            return WrapWithValueException(path,
-                () => GetDecimalList(HoconPath.Parse(path)) ??
-                      throw new HoconParserException($"Hocon path {path} does not exist."));
+            return WrapWithValueException(path, () => GetNode(path).GetDecimalList());
+        }
+
+        public virtual IList<decimal> GetDecimalList(HoconPath path)
+        {
+            return WrapWithValueException(path, () => GetNode(path).GetDecimalList());
         }
 
         /// <summary>
@@ -492,17 +660,21 @@ namespace Hocon
         /// <returns>The list of decimal values defined in the specified path.</returns>
         public virtual IList<decimal> GetDecimalList(string path, IList<decimal> @default)
         {
-            return WrapWithValueException(path, () => GetDecimalList(HoconPath.Parse(path), @default));
+            if (TryGetNode(path, out var value))
+                if (value.TryGetDecimalList(out var result))
+                    return result;
+
+            return @default;
         }
 
         /// <inheritdoc cref="GetDecimalList(string)" />
-        public virtual IList<decimal> GetDecimalList(HoconPath path, IList<decimal> @default = null)
+        public virtual IList<decimal> GetDecimalList(HoconPath path, IList<decimal> @default)
         {
-            return WrapWithValueException(path.ToString(), () =>
-            {
-                var value = GetNode(path);
-                return value == null ? @default : value.GetDecimalList();
-            });
+            if (TryGetNode(path, out var value))
+                if (value.TryGetDecimalList(out var result))
+                    return result;
+
+            return @default;
         }
 
         /// <summary>
@@ -513,9 +685,12 @@ namespace Hocon
         /// <exception cref="HoconParserException">Thrown if path does not exist</exception>
         public virtual IList<float> GetFloatList(string path)
         {
-            return WrapWithValueException(path,
-                () => GetFloatList(HoconPath.Parse(path)) ??
-                      throw new HoconParserException($"Hocon path {path} does not exist."));
+            return WrapWithValueException(path, () => GetNode(path).GetFloatList());
+        }
+
+        public virtual IList<float> GetFloatList(HoconPath path)
+        {
+            return WrapWithValueException(path, () => GetNode(path).GetFloatList());
         }
 
         /// <summary>
@@ -526,17 +701,21 @@ namespace Hocon
         /// <returns>The list of float values defined in the specified path.</returns>
         public virtual IList<float> GetFloatList(string path, IList<float> @default)
         {
-            return WrapWithValueException(path, () => GetFloatList(HoconPath.Parse(path), @default));
+            if (TryGetNode(path, out var value))
+                if (value.TryGetFloatList(out var result))
+                    return result;
+
+            return @default;
         }
 
         /// <inheritdoc cref="GetFloatList(string)" />
-        public virtual IList<float> GetFloatList(HoconPath path, IList<float> @default = null)
+        public virtual IList<float> GetFloatList(HoconPath path, IList<float> @default)
         {
-            return WrapWithValueException(path.ToString(), () =>
-            {
-                var value = GetNode(path);
-                return value == null ? @default : value.GetFloatList();
-            });
+            if (TryGetNode(path, out var value))
+                if (value.TryGetFloatList(out var result))
+                    return result;
+
+            return @default;
         }
 
         /// <summary>
@@ -547,9 +726,12 @@ namespace Hocon
         /// <exception cref="HoconParserException">Thrown if path does not exist</exception>
         public virtual IList<double> GetDoubleList(string path)
         {
-            return WrapWithValueException(path,
-                () => GetDoubleList(HoconPath.Parse(path)) ??
-                      throw new HoconParserException($"Hocon path {path} does not exist."));
+            return WrapWithValueException(path, () => GetNode(path).GetDoubleList());
+        }
+
+        public virtual IList<double> GetDoubleList(HoconPath path)
+        {
+            return WrapWithValueException(path, () => GetNode(path).GetDoubleList());
         }
 
         /// <summary>
@@ -560,17 +742,21 @@ namespace Hocon
         /// <returns>The list of double values defined in the specified path.</returns>
         public virtual IList<double> GetDoubleList(string path, IList<double> @default)
         {
-            return WrapWithValueException(path, () => GetDoubleList(HoconPath.Parse(path), @default));
+            if (TryGetNode(path, out var value))
+                if (value.TryGetDoubleList(out var result))
+                    return result;
+
+            return @default;
         }
 
         /// <inheritdoc cref="GetDoubleList(string)" />
-        public virtual IList<double> GetDoubleList(HoconPath path, IList<double> @default = null)
+        public virtual IList<double> GetDoubleList(HoconPath path, IList<double> @default)
         {
-            return WrapWithValueException(path.ToString(), () =>
-            {
-                var value = GetNode(path);
-                return value == null ? @default : value.GetDoubleList();
-            });
+            if (TryGetNode(path, out var value))
+                if (value.TryGetDoubleList(out var result))
+                    return result;
+
+            return @default;
         }
 
         /// <summary>
@@ -581,9 +767,12 @@ namespace Hocon
         /// <exception cref="HoconParserException">Thrown if path does not exist</exception>
         public virtual IList<int> GetIntList(string path)
         {
-            return WrapWithValueException(path,
-                () => GetIntList(HoconPath.Parse(path)) ??
-                      throw new HoconParserException($"Hocon path {path} does not exist."));
+            return WrapWithValueException(path, () => GetNode(path).GetIntList());
+        }
+
+        public virtual IList<int> GetIntList(HoconPath path)
+        {
+            return WrapWithValueException(path, () => GetNode(path).GetIntList());
         }
 
         /// <summary>
@@ -594,17 +783,21 @@ namespace Hocon
         /// <returns>The list of int values defined in the specified path.</returns>
         public virtual IList<int> GetIntList(string path, IList<int> @default)
         {
-            return WrapWithValueException(path, () => GetIntList(HoconPath.Parse(path), @default));
+            if (TryGetNode(path, out var value))
+                if (value.TryGetIntList(out var result))
+                    return result;
+
+            return @default;
         }
 
         /// <inheritdoc cref="GetIntList(string)" />
-        public virtual IList<int> GetIntList(HoconPath path, IList<int> @default = null)
+        public virtual IList<int> GetIntList(HoconPath path, IList<int> @default)
         {
-            return WrapWithValueException(path.ToString(), () =>
-            {
-                var value = GetNode(path);
-                return value == null ? @default : value.GetIntList();
-            });
+            if (TryGetNode(path, out var value))
+                if (value.TryGetIntList(out var result))
+                    return result;
+
+            return @default;
         }
 
         /// <summary>
@@ -615,9 +808,12 @@ namespace Hocon
         /// <exception cref="HoconParserException">Thrown if path does not exist</exception>
         public virtual IList<long> GetLongList(string path)
         {
-            return WrapWithValueException(path,
-                () => GetLongList(HoconPath.Parse(path)) ??
-                      throw new HoconParserException($"Hocon path {path} does not exist."));
+            return WrapWithValueException(path, () => GetNode(path).GetLongList());
+        }
+
+        public virtual IList<long> GetLongList(HoconPath path)
+        {
+            return WrapWithValueException(path, () => GetNode(path).GetLongList());
         }
 
         /// <summary>
@@ -628,17 +824,21 @@ namespace Hocon
         /// <returns>The list of long values defined in the specified path.</returns>
         public virtual IList<long> GetLongList(string path, IList<long> @default)
         {
-            return WrapWithValueException(path, () => GetLongList(HoconPath.Parse(path), @default));
+            if (TryGetNode(path, out var value))
+                if (value.TryGetLongList(out var result))
+                    return result;
+
+            return @default;
         }
 
         /// <inheritdoc cref="GetLongList(string)" />
-        public virtual IList<long> GetLongList(HoconPath path, IList<long> @default = null)
+        public virtual IList<long> GetLongList(HoconPath path, IList<long> @default)
         {
-            return WrapWithValueException(path.ToString(), () =>
-            {
-                var value = GetNode(path);
-                return value == null ? @default : value.GetLongList();
-            });
+            if (TryGetNode(path, out var value))
+                if (value.TryGetLongList(out var result))
+                    return result;
+
+            return @default;
         }
 
         /// <summary>
@@ -649,9 +849,12 @@ namespace Hocon
         /// <exception cref="HoconParserException">Thrown if path does not exist</exception>
         public virtual IList<byte> GetByteList(string path)
         {
-            return WrapWithValueException(path,
-                () => GetByteList(HoconPath.Parse(path)) ??
-                      throw new HoconParserException($"Hocon path {path} does not exist."));
+            return WrapWithValueException(path, () => GetNode(path).GetByteList());
+        }
+
+        public virtual IList<byte> GetByteList(HoconPath path)
+        {
+            return WrapWithValueException(path, () => GetNode(path).GetByteList());
         }
 
         /// <summary>
@@ -662,17 +865,21 @@ namespace Hocon
         /// <returns>The list of byte values defined in the specified path.</returns>
         public virtual IList<byte> GetByteList(string path, IList<byte> @default)
         {
-            return WrapWithValueException(path, () => GetByteList(HoconPath.Parse(path), @default));
+            if (TryGetNode(path, out var value))
+                if (value.TryGetByteList(out var result))
+                    return result;
+
+            return @default;
         }
 
         /// <inheritdoc cref="GetByteList(string)" />
-        public virtual IList<byte> GetByteList(HoconPath path, IList<byte> @default = null)
+        public virtual IList<byte> GetByteList(HoconPath path, IList<byte> @default)
         {
-            return WrapWithValueException(path.ToString(), () =>
-            {
-                var value = GetNode(path);
-                return value == null ? @default : value.GetByteList();
-            });
+            if (TryGetNode(path, out var value))
+                if (value.TryGetByteList(out var result))
+                    return result;
+
+            return @default;
         }
 
         /// <summary>
@@ -680,11 +887,16 @@ namespace Hocon
         /// </summary>
         /// <param name="path">The path that contains the values to retrieve.</param>
         /// <returns>The list of string values defined in the specified path.</returns>
-        /// <exception cref="HoconParserException">Thrown if path does not exist</exception>
+        [Obsolete("Check for default value")]
         public virtual IList<string> GetStringList(string path)
         {
-            return WrapWithValueException(path,
-                () => GetStringList(HoconPath.Parse(path)) ?? new List<string>());
+            return WrapWithValueException(path, () => GetNode(path).GetStringList() ?? new List<string>());
+        }
+
+        [Obsolete("Check for default value")]
+        public virtual IList<string> GetStringList(HoconPath path)
+        {
+            return WrapWithValueException(path, () => GetNode(path).GetStringList() ?? new List<string>());
         }
 
         /// <summary>
@@ -695,17 +907,21 @@ namespace Hocon
         /// <returns>The list of string values defined in the specified path.</returns>
         public virtual IList<string> GetStringList(string path, IList<string> @default)
         {
-            return WrapWithValueException(path, () => GetStringList(HoconPath.Parse(path), @default));
+            if (TryGetNode(path, out var value))
+                if (value.TryGetStringList(out var result))
+                    return result;
+
+            return @default;
         }
 
         /// <inheritdoc cref="GetStringList(string)" />
-        public virtual IList<string> GetStringList(HoconPath path, IList<string> @default = null)
+        public virtual IList<string> GetStringList(HoconPath path, IList<string> @default)
         {
-            return WrapWithValueException(path.ToString(), () =>
-            {
-                var value = GetNode(path);
-                return value == null ? @default : value.GetStringList();
-            });
+            if (TryGetNode(path, out var value))
+                if (value.TryGetStringList(out var result))
+                    return result;
+
+            return @default;
         }
 
         /// <summary>
@@ -716,9 +932,12 @@ namespace Hocon
         /// <exception cref="HoconParserException">Thrown if path does not exist</exception>
         public virtual IList<HoconObject> GetObjectList(string path)
         {
-            return WrapWithValueException(path,
-                () => GetObjectList(HoconPath.Parse(path)) ??
-                      throw new HoconParserException($"Hocon path {path} does not exist."));
+            return WrapWithValueException(path, () => GetNode(path).GetObjectList());
+        }
+
+        public virtual IList<HoconObject> GetObjectList(HoconPath path)
+        {
+            return WrapWithValueException(path, () => GetNode(path).GetObjectList());
         }
 
         /// <summary>
@@ -729,17 +948,21 @@ namespace Hocon
         /// <returns>The list of objects defined in the specified path.</returns>
         public virtual IList<HoconObject> GetObjectList(string path, IList<HoconObject> @default)
         {
-            return WrapWithValueException(path, () => GetObjectList(HoconPath.Parse(path), @default));
+            if (TryGetNode(path, out var value))
+                if (value.TryGetObjectList(out var result))
+                    return result;
+
+            return @default;
         }
 
         /// <inheritdoc cref="GetObjectList(string)" />
         public virtual IList<HoconObject> GetObjectList(HoconPath path, IList<HoconObject> @default = null)
         {
-            return WrapWithValueException(path.ToString(), () =>
-            {
-                var value = GetNode(path);
-                return value == null ? @default : value.GetObjectList();
-            });
+            if (TryGetNode(path, out var value))
+                if (value.TryGetObjectList(out var result))
+                    return result;
+
+            return @default;
         }
 
         /// <summary>
@@ -749,17 +972,23 @@ namespace Hocon
         /// <returns>The <see cref="HoconValue" /> found at the location if one exists, otherwise <c>null</c>.</returns>
         public virtual HoconValue GetValue(string path)
         {
-            return WrapWithValueException(path, () => GetValue(HoconPath.Parse(path)));
+            return WrapWithValueException(path, () => GetNode(path));
         }
 
         /// <inheritdoc cref="GetValue(string)" />
         public virtual HoconValue GetValue(HoconPath path)
         {
-            return WrapWithValueException(path.ToString(), () =>
-            {
-                var value = GetNode(path);
-                return value;
-            });
+            return WrapWithValueException(path, () => GetNode(path));
+        }
+
+        public virtual bool TryGetValue(string path, out HoconValue result)
+        {
+            return TryGetNode(path, out result);
+        }
+
+        public virtual bool TryGetValue(HoconPath path, out HoconValue result)
+        {
+            return TryGetNode(path, out result);
         }
 
         [Obsolete("Use GetTimeSpan instead")]
@@ -782,21 +1011,34 @@ namespace Hocon
         /// <param name="default">The default value to return if the value doesn't exist.</param>
         /// <param name="allowInfinite"><c>true</c> if infinite timespans are allowed; otherwise <c>false</c>.</param>
         /// <returns>The <see cref="TimeSpan" /> value defined in the specified path.</returns>
-        public virtual TimeSpan GetTimeSpan(string path, TimeSpan? @default = null, bool allowInfinite = true)
+        public virtual TimeSpan GetTimeSpan(string path, bool allowInfinite = true)
         {
-            return WrapWithValueException(path, () => GetTimeSpan(HoconPath.Parse(path), @default, allowInfinite));
+            return WrapWithValueException(path, () => GetNode(path).GetTimeSpan(allowInfinite));
         }
 
-        /// <inheritdoc cref="GetTimeSpan(string,System.Nullable{System.TimeSpan},bool)" />
-        public virtual TimeSpan GetTimeSpan(HoconPath path, TimeSpan? @default = null, bool allowInfinite = true)
+        public virtual TimeSpan GetTimeSpan(HoconPath path, bool allowInfinite = true)
         {
-            return WrapWithValueException(path.ToString(), () =>
-            {
-                var value = GetNode(path);
-                return value == null ? @default.GetValueOrDefault() : value.GetTimeSpan(allowInfinite);
-            });
+            return WrapWithValueException(path, () => GetNode(path).GetTimeSpan(allowInfinite));
         }
 
+        public virtual TimeSpan GetTimeSpan(string path, TimeSpan? @default, bool allowInfinite = true)
+        {
+            if (TryGetNode(path, out var value))
+                if (value.TryGetTimeSpan(out var result, allowInfinite))
+                    return result;
+
+            return @default.GetValueOrDefault();
+        }
+
+        public virtual TimeSpan GetTimeSpan(HoconPath path, TimeSpan? @default, bool allowInfinite = true)
+        {
+            if (TryGetNode(path, out var value))
+                if (value.TryGetTimeSpan(out var result, allowInfinite))
+                    return result;
+
+            return @default.GetValueOrDefault();
+        }
+        #endregion
         #endregion
     }
 }

--- a/src/Hocon/Impl/HoconObject.cs
+++ b/src/Hocon/Impl/HoconObject.cs
@@ -128,6 +128,31 @@ namespace Hocon
             return sortedDict.Values.ToList();
         }
 
+        public bool TryGetArray(out List<HoconValue> result)
+        {
+            result = new List<HoconValue>();
+
+            var sortedDict = new SortedDictionary<int, HoconValue>();
+            var type = HoconType.Empty;
+            foreach (var field in Values)
+            {
+                if (field.Value == null || !int.TryParse(field.Key, out var index) || index < 0)
+                    continue;
+                if (type == HoconType.Empty)
+                    type = field.Type;
+                else if (type != field.Type)
+                    return false;
+
+                sortedDict[index] = field.Value;
+            }
+
+            if (sortedDict.Count == 0)
+                return false;
+
+            result = sortedDict.Values.ToList();
+            return true;
+        }
+
         /// <inheritdoc />
         public string ToString(int indent, int indentSize)
         {

--- a/src/Hocon/Impl/HoconObject.cs
+++ b/src/Hocon/Impl/HoconObject.cs
@@ -40,6 +40,10 @@ namespace Hocon
             _empty = new HoconObject(value);
         }
 
+        [Obsolete("Only used for serialization", true)]
+        private HoconObject()
+        { }
+
         /// <summary>
         ///     Initializes a new instance of the <see cref="HoconObject" /> class.
         /// </summary>

--- a/src/Hocon/Impl/HoconObject.cs
+++ b/src/Hocon/Impl/HoconObject.cs
@@ -31,6 +31,15 @@ namespace Hocon
     /// </summary>
     public class HoconObject : Dictionary<string, HoconField>, IHoconElement
     {
+        private static readonly HoconObject _empty;
+        public static HoconObject Empty => _empty;
+
+        static HoconObject()
+        {
+            var value = new HoconValue(null);
+            _empty = new HoconObject(value);
+        }
+
         /// <summary>
         ///     Initializes a new instance of the <see cref="HoconObject" /> class.
         /// </summary>
@@ -63,6 +72,8 @@ namespace Hocon
                 return HoconPath.Empty;
             }
         }
+
+        public bool IsEmpty => Count == 0;
 
         /// <summary>
         ///     Retrieves the underlying map that contains the barebones

--- a/src/Hocon/Impl/HoconPath.cs
+++ b/src/Hocon/Impl/HoconPath.cs
@@ -159,6 +159,20 @@ namespace Hocon
             return new HoconPath(result);
         }
 
+        public static bool TryParse(string path, out HoconPath result)
+        {
+            result = null;
+            if (path == null)
+                return false;
+            try
+            {
+                result = FromTokens(new HoconTokenizer(path).Tokenize());
+                return true;
+            } catch {
+                return false;
+            }
+        }
+
         public static HoconPath Parse(string path)
         {
             if (path == null)

--- a/src/Hocon/Impl/HoconValue.cs
+++ b/src/Hocon/Impl/HoconValue.cs
@@ -313,10 +313,10 @@ namespace Hocon
                     case HoconType.Boolean:
                     case HoconType.Number:
                     case HoconType.String:
-                        var literalList = new List<HoconLiteral>();
-                        foreach(var lit in clonedValue)
-                            literalList.Add((HoconLiteral)lit);
-                        InsertRange(index, literalList);
+                        var elementList = new List<IHoconElement>();
+                        foreach(var element in clonedValue)
+                            elementList.Add(element);
+                        InsertRange(index, elementList);
                         break;
                 }
             }

--- a/src/Hocon/Impl/HoconValue.cs
+++ b/src/Hocon/Impl/HoconValue.cs
@@ -45,6 +45,12 @@ namespace Hocon
         /// <inheritdoc />
         public virtual HoconObject GetObject()
         {
+            if (Type == HoconType.Empty)
+                return null;
+
+            if (Type != HoconType.Object)
+                throw new HoconException($"Could not convert HoconValue of type {Type} into {nameof(HoconType.Object)}");
+
             var objects = this
                 .Where(value => value.Type == HoconType.Object)
                 .Select(value => value.GetObject()).ToList();
@@ -60,13 +66,50 @@ namespace Hocon
             }
         }
 
+        public virtual bool TryGetObject(out HoconObject result)
+        {
+            result = null;
+            if (Type != HoconType.Object)
+                return false;
+
+            var objects = this
+                .Where(value => value.Type == HoconType.Object)
+                .Select(value => value.GetObject()).ToList();
+
+            switch (objects.Count)
+            {
+                case 0:
+                    break;
+                case 1:
+                    result = objects[0];
+                    break;
+                default:
+                    result = new HoconMergedObject(this, objects);
+                    break;
+            }
+            return true;
+        }
+
         /// <summary>
         ///     Retrieves the string value from this <see cref="T:Hocon.HoconValue" />.
         /// </summary>
         /// <returns>The string value represented by this <see cref="T:Hocon.HoconValue" />.</returns>
         public virtual string GetString()
         {
-            return !Type.IsLiteral() ? null : ConcatString();
+            return Type.IsLiteral() ? 
+                ConcatString() : 
+                throw new HoconException($"Could not convert '{Type}' to string.");
+        }
+
+        public virtual bool TryGetString(out string result)
+        {
+            result = null;
+            if (Type.IsLiteral())
+            {
+                result = ConcatString();
+                return true;
+            }
+            return false;
         }
 
         public virtual string Raw
@@ -87,14 +130,6 @@ namespace Hocon
                             result.AddRange(element.GetArray());
 
                     return result;
-                /*
-                IEnumerable<HoconValue> x = from value in this
-                    where value.Type == HoconType.Array
-                    from e in value.GetArray()
-                    select e;
-
-                return x.ToList();
-                */
 
                 case HoconType.Object:
                     return GetObject().GetArray();
@@ -109,6 +144,28 @@ namespace Hocon
 
                 default:
                     throw new Exception($"Unknown HoconType: {Type}");
+            }
+        }
+
+        public virtual bool TryGetArray(out List<HoconValue> result)
+        {
+            result = new List<HoconValue>();
+            switch (Type)
+            {
+                case HoconType.Array:
+                    foreach (var element in this)
+                        if (element.Type == HoconType.Array)
+                            result.AddRange(element.GetArray());
+
+                    return true;
+
+                case HoconType.Object:
+                    if (TryGetObject(out var obj))
+                        return obj.TryGetArray(out result);
+                    return false;
+
+                default:
+                    return false;
             }
         }
 
@@ -350,6 +407,24 @@ namespace Hocon
             }
         }
 
+        public bool TryGetBoolean(out bool result)
+        {
+            result = default(bool);
+            if (!TryGetString(out var value))
+                return false;
+
+            switch (value)
+            {
+                case "on":
+                case "true":
+                case "yes":
+                    result = true;
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
         /// <summary>
         ///     Retrieves the decimal value from this <see cref="HoconValue" />.
         /// </summary>
@@ -374,6 +449,24 @@ namespace Hocon
                     {
                         throw new HoconException($"Could not convert `{value}` to decimal.", e);
                     }
+            }
+        }
+
+        public bool TryGetDecimal(out decimal result)
+        {
+            result = default(decimal);
+            if (!TryGetString(out var value))
+                return false;
+
+            switch (value)
+            {
+                case "+Infinity":
+                case "Infinity":
+                case "-Infinity":
+                case "NaN":
+                    return false;
+                default:
+                    return decimal.TryParse(value, NumberStyles.Any, NumberFormatInfo.InvariantInfo, out result);
             }
         }
 
@@ -405,6 +498,28 @@ namespace Hocon
             }
         }
 
+        public bool TryGetFloat(out float result)
+        {
+            result = default(float);
+            if (!TryGetString(out var value))
+                return false;
+            switch (value)
+            {
+                case "+Infinity":
+                case "Infinity":
+                    result = float.PositiveInfinity;
+                    return true;
+                case "-Infinity":
+                    result = float.NegativeInfinity;
+                    return true;
+                case "NaN":
+                    result = float.NaN;
+                    return true;
+                default:
+                    return float.TryParse(value, NumberStyles.Any, NumberFormatInfo.InvariantInfo, out result);
+            }
+        }
+
         /// <summary>
         ///     Retrieves the double value from this <see cref="HoconValue" />.
         /// </summary>
@@ -430,6 +545,29 @@ namespace Hocon
                     {
                         throw new HoconException($"Could not convert `{value}` to double.", e);
                     }
+            }
+        }
+
+        public bool TryGetDouble(out double result)
+        {
+            result = default(double);
+            if (!TryGetString(out var value))
+                return false;
+
+            switch (value)
+            {
+                case "+Infinity":
+                case "Infinity":
+                    result = double.PositiveInfinity;
+                    return true;
+                case "-Infinity":
+                    result = double.NegativeInfinity;
+                    return true;
+                case "NaN":
+                    result = double.NaN;
+                    return true;
+                default:
+                    return double.TryParse(value, NumberStyles.Any, NumberFormatInfo.InvariantInfo, out result);
             }
         }
 
@@ -468,6 +606,37 @@ namespace Hocon
             {
                 throw new HoconException($"Could not convert `{GetString()}` to long.", e);
             }
+        }
+
+        public bool TryGetLong(out long result)
+        {
+            result = default(long);
+            if (!TryGetString(out var value))
+                return false;
+
+            if (value.StartsWith("0x"))
+                try
+                {
+                    result = Convert.ToInt64(value, 16);
+                    return true;
+                }
+                catch
+                {
+                    return false;
+                }
+
+            if (value.StartsWith("0"))
+                try
+                {
+                    result = Convert.ToInt64(value, 8);
+                    return true;
+                }
+                catch
+                {
+                    return false;
+                }
+
+            return long.TryParse(value, NumberStyles.Integer, NumberFormatInfo.InvariantInfo, out result);
         }
 
         /// <summary>
@@ -510,6 +679,37 @@ namespace Hocon
             }
         }
 
+        public bool TryGetInt(out int result)
+        {
+            result = default(int);
+            if (!TryGetString(out var value))
+                return false;
+
+            if (value.StartsWith("0x"))
+                try
+                {
+                    result = Convert.ToInt32(value, 16);
+                    return true;
+                }
+                catch
+                {
+                    return false;
+                }
+
+            if (value.StartsWith("0"))
+                try
+                {
+                    result = Convert.ToInt32(value, 8);
+                    return true;
+                }
+                catch
+                {
+                    return false;
+                }
+
+            return int.TryParse(value, NumberStyles.Integer, NumberFormatInfo.InvariantInfo, out result);
+        }
+
         /// <summary>
         ///     Retrieves the byte value from this <see cref="HoconValue" />.
         /// </summary>
@@ -547,6 +747,37 @@ namespace Hocon
             }
         }
 
+        public bool TryGetByte(out byte result)
+        {
+            result = default(byte);
+            if (!TryGetString(out var value))
+                return false;
+
+            if (value.StartsWith("0x"))
+                try
+                {
+                    result = Convert.ToByte(value, 16);
+                    return true;
+                }
+                catch
+                {
+                    return false;
+                }
+
+            if (value.StartsWith("0"))
+                try
+                {
+                    result = Convert.ToByte(value, 8);
+                    return true;
+                }
+                catch
+                {
+                    return false;
+                }
+
+            return byte.TryParse(value, NumberStyles.Integer, NumberFormatInfo.InvariantInfo, out result);
+        }
+
         /// <summary>
         ///     Retrieves a list of byte values from this <see cref="HoconValue" />.
         /// </summary>
@@ -554,6 +785,24 @@ namespace Hocon
         public IList<byte> GetByteList()
         {
             return GetArray().Select(v => v.GetByte()).ToList();
+        }
+
+        public bool TryGetByteList(out IList<byte> result)
+        {
+            result = default(List<byte>);
+            if(TryGetArray(out var arr))
+            {
+                var list = new List<byte>();
+                foreach(var val in arr)
+                {
+                    if (!val.TryGetByte(out var res))
+                        return false;
+                    list.Add(res);
+                }
+                result = list;
+                return true;
+            }
+            return false;
         }
 
         /// <summary>
@@ -565,6 +814,24 @@ namespace Hocon
             return GetArray().Select(v => v.GetInt()).ToList();
         }
 
+        public bool TryGetIntList(out IList<int> result)
+        {
+            result = default(List<int>);
+            if (TryGetArray(out var arr))
+            {
+                var list = new List<int>();
+                foreach (var val in arr)
+                {
+                    if (!val.TryGetInt(out var res))
+                        return false;
+                    list.Add(res);
+                }
+                result = list;
+                return true;
+            }
+            return false;
+        }
+
         /// <summary>
         ///     Retrieves a list of long values from this <see cref="HoconValue" />.
         /// </summary>
@@ -572,6 +839,24 @@ namespace Hocon
         public IList<long> GetLongList()
         {
             return GetArray().Select(v => v.GetLong()).ToList();
+        }
+
+        public bool TryGetLongList(out IList<long> result)
+        {
+            result = default(List<long>);
+            if (TryGetArray(out var arr))
+            {
+                var list = new List<long>();
+                foreach (var val in arr)
+                {
+                    if (!val.TryGetLong(out var res))
+                        return false;
+                    list.Add(res);
+                }
+                result = list;
+                return true;
+            }
+            return false;
         }
 
         /// <summary>
@@ -583,6 +868,24 @@ namespace Hocon
             return GetArray().Select(v => v.GetBoolean()).ToList();
         }
 
+        public bool TryGetBooleanList(out IList<bool> result)
+        {
+            result = default(List<bool>);
+            if (TryGetArray(out var arr))
+            {
+                var list = new List<bool>();
+                foreach (var val in arr)
+                {
+                    if (!val.TryGetBoolean(out var res))
+                        return false;
+                    list.Add(res);
+                }
+                result = list;
+                return true;
+            }
+            return false;
+        }
+
         /// <summary>
         ///     Retrieves a list of float values from this <see cref="HoconValue" />.
         /// </summary>
@@ -590,6 +893,24 @@ namespace Hocon
         public IList<float> GetFloatList()
         {
             return GetArray().Select(v => v.GetFloat()).ToList();
+        }
+
+        public bool TryGetFloatList(out IList<float> result)
+        {
+            result = default(List<float>);
+            if (TryGetArray(out var arr))
+            {
+                var list = new List<float>();
+                foreach (var val in arr)
+                {
+                    if (!val.TryGetFloat(out var res))
+                        return false;
+                    list.Add(res);
+                }
+                result = list;
+                return true;
+            }
+            return false;
         }
 
         /// <summary>
@@ -601,6 +922,24 @@ namespace Hocon
             return GetArray().Select(v => v.GetDouble()).ToList();
         }
 
+        public bool TryGetDoubleList(out IList<double> result)
+        {
+            result = default(List<double>);
+            if (TryGetArray(out var arr))
+            {
+                var list = new List<double>();
+                foreach (var val in arr)
+                {
+                    if (!val.TryGetDouble(out var res))
+                        return false;
+                    list.Add(res);
+                }
+                result = list;
+                return true;
+            }
+            return false;
+        }
+
         /// <summary>
         ///     Retrieves a list of decimal values from this <see cref="HoconValue" />.
         /// </summary>
@@ -608,6 +947,24 @@ namespace Hocon
         public IList<decimal> GetDecimalList()
         {
             return GetArray().Select(v => v.GetDecimal()).ToList();
+        }
+
+        public bool TryGetDecimalList(out IList<decimal> result)
+        {
+            result = default(List<decimal>);
+            if (TryGetArray(out var arr))
+            {
+                var list = new List<decimal>();
+                foreach (var val in arr)
+                {
+                    if (!val.TryGetDecimal(out var res))
+                        return false;
+                    list.Add(res);
+                }
+                result = list;
+                return true;
+            }
+            return false;
         }
 
         /// <summary>
@@ -619,6 +976,24 @@ namespace Hocon
             return GetArray().Select(v => v.GetString()).ToList();
         }
 
+        public bool TryGetStringList(out IList<string> result)
+        {
+            result = default(List<string>);
+            if (TryGetArray(out var arr))
+            {
+                var list = new List<string>();
+                foreach (var val in arr)
+                {
+                    if (!val.TryGetString(out var res))
+                        return false;
+                    list.Add(res);
+                }
+                result = list;
+                return true;
+            }
+            return false;
+        }
+
         /// <summary>
         ///     Retrieves a list of objects from this <see cref="HoconValue" />.
         /// </summary>
@@ -626,6 +1001,24 @@ namespace Hocon
         public IList<HoconObject> GetObjectList()
         {
             return GetArray().Select(v => v.GetObject()).ToList();
+        }
+
+        public bool TryGetObjectList(out IList<HoconObject> result)
+        {
+            result = default(List<HoconObject>);
+            if (TryGetArray(out var arr))
+            {
+                var list = new List<HoconObject>();
+                foreach (var val in arr)
+                {
+                    if (!val.TryGetObject(out var res))
+                        return false;
+                    list.Add(res);
+                }
+                result = list;
+                return true;
+            }
+            return false;
         }
 
         [Obsolete("Use GetTimeSpan instead")]
@@ -643,67 +1036,114 @@ namespace Hocon
         {
             string res = GetString();
 
-            var match = TimeSpanRegex.Match(res);
-            if (match.Success)
-            {
-                var u = match.Groups["unit"].Value;
-                var v = ParsePositiveValue(match.Groups["value"].Value);
-
-                switch (u)
-                {
-                    case "nanoseconds":
-                    case "nanosecond":
-                    case "nanos":
-                    case "nano":
-                    case "ns":
-                        return TimeSpan.FromTicks((long) Math.Round(TimeSpan.TicksPerMillisecond * v / 1000000.0));
-                    case "microseconds":
-                    case "microsecond":
-                    case "micros":
-                    case "micro":
-                        return TimeSpan.FromTicks((long) Math.Round(TimeSpan.TicksPerMillisecond * v / 1000.0));
-                    case "milliseconds":
-                    case "millisecond":
-                    case "millis":
-                    case "milli":
-                    case "ms":
-                        return TimeSpan.FromMilliseconds(v);
-                    case "seconds":
-                    case "second":
-                    case "s":
-                        return TimeSpan.FromSeconds(v);
-                    case "minutes":
-                    case "minute":
-                    case "m":
-                        return TimeSpan.FromMinutes(v);
-                    case "hours":
-                    case "hour":
-                    case "h":
-                        return TimeSpan.FromHours(v);
-                    case "days":
-                    case "day":
-                    case "d":
-                        return TimeSpan.FromDays(v);
-                }
-            }
+            if (TryMatchTimeSpan(res, out var result))
+                return result;
 
             if (allowInfinite && res.Equals("infinite", StringComparison.OrdinalIgnoreCase)) //Not in Hocon spec
                 return Timeout.InfiniteTimeSpan;
 
-            return TimeSpan.FromMilliseconds(ParsePositiveValue(res));
-        }
-
-        private static double ParsePositiveValue(string v)
-        {
-            // This NumberStyles are used in double.TryParse(v, out var value) overload internally
-            if (!double.TryParse(v, NumberStyles.Float | NumberStyles.AllowThousands, NumberFormatInfo.InvariantInfo,
-                out var value))
-                throw new FormatException($"Failed to parse TimeSpan value from '{v}'");
+            double value;
+            try
+            {
+                value = double.Parse(res, NumberStyles.Float | NumberStyles.AllowThousands, NumberFormatInfo.InvariantInfo);
+            }
+            catch (Exception e)
+            {
+                throw new HoconException($"Failed to parse TimeSpan value from '{res}'", e);
+            }
 
             if (value < 0)
-                throw new FormatException("Expected a positive value instead of " + value);
+                throw new HoconException("Expected a positive value instead of " + value);
 
-            return value;
+            return TimeSpan.FromMilliseconds(value);
+        }
+
+        public bool TryGetTimeSpan(out TimeSpan result, bool allowInfinite = true)
+        {
+            result = default(TimeSpan);
+            if (!TryGetString(out var res))
+                return false;
+
+            if (TryMatchTimeSpan(res, out result))
+                return true;
+
+            if (allowInfinite && res.Equals("infinite", StringComparison.OrdinalIgnoreCase)) //Not in Hocon spec
+            {
+                result = Timeout.InfiniteTimeSpan;
+                return true;
+            }
+
+            if (!double.TryParse(res, NumberStyles.Float | NumberStyles.AllowThousands, NumberFormatInfo.InvariantInfo, out var doubleValue))
+                return false;
+
+            if (doubleValue < 0) return false;
+
+            result = TimeSpan.FromMilliseconds(doubleValue);
+            return true;
+        }
+
+        private bool TryMatchTimeSpan(string value, out TimeSpan result)
+        {
+            result = default(TimeSpan);
+
+            var match = TimeSpanRegex.Match(value);
+            if (!match.Success)
+                return false;
+
+            var u = match.Groups["unit"].Value;
+            if (!double.TryParse(
+                    match.Groups["value"].Value,
+                    NumberStyles.Float | NumberStyles.AllowThousands,
+                    NumberFormatInfo.InvariantInfo,
+                    out var v))
+                return false;
+
+            if (v < 0) return false;
+
+            switch (u)
+            {
+                case "nanoseconds":
+                case "nanosecond":
+                case "nanos":
+                case "nano":
+                case "ns":
+                    result = TimeSpan.FromTicks((long)Math.Round(TimeSpan.TicksPerMillisecond * v / 1000000.0));
+                    return true;
+                case "microseconds":
+                case "microsecond":
+                case "micros":
+                case "micro":
+                    result = TimeSpan.FromTicks((long)Math.Round(TimeSpan.TicksPerMillisecond * v / 1000.0));
+                    return true;
+                case "milliseconds":
+                case "millisecond":
+                case "millis":
+                case "milli":
+                case "ms":
+                    result = TimeSpan.FromMilliseconds(v);
+                    return true;
+                case "seconds":
+                case "second":
+                case "s":
+                    result = TimeSpan.FromSeconds(v);
+                    return true;
+                case "minutes":
+                case "minute":
+                case "m":
+                    result = TimeSpan.FromMinutes(v);
+                    return true;
+                case "hours":
+                case "hour":
+                case "h":
+                    result = TimeSpan.FromHours(v);
+                    return true;
+                case "days":
+                case "day":
+                case "d":
+                    result = TimeSpan.FromDays(v);
+                    return true;
+            }
+            return false;
         }
 
         private struct ByteSize


### PR DESCRIPTION
Still related to https://github.com/akkadotnet/akka.net/pull/4128

- Add `IEquitable<Config>` interface implementation to `Config` class
- `GetString()`, `GetStringList()`, `GetInt()`, and `GetDouble()` throws on failure instead of returning a default value (Major change in Akka.NET).
- Add `TryGet[DataType]()` functions to all getters to eliminate as much Exception throwing as possible to improve performance.
- Remove as much wrapping functions as possible to improve performance.
- Move ConfigurationException from Akka.Configuration to Hocon
- Fix Config.WithFallback() with hocon files containing substitution failed to merge the fallbacks correctly.