### PR TITLE
Fix unquoted key error during serialization.

### DIFF
--- a/src/Hocon.Configuration.Test/SerializationSpecs.cs
+++ b/src/Hocon.Configuration.Test/SerializationSpecs.cs
@@ -62,5 +62,19 @@ namespace Hocon.Configuration.Tests
             HoconConfigurationFactory.ParseString("{}").IsEmpty.Should().BeTrue();
             Config.Empty.IsEmpty.Should().BeTrue();
         }
+
+        [Fact]
+        public void QuotedKeyWithInvalidCharactersShouldSerializeProperly()
+        {
+            var hoconString = @"this.""should[]"".work = true";
+            var config = HoconConfigurationFactory.ParseString(hoconString);
+            var serialized = JsonConvert.SerializeObject(config);
+            var deserialized = JsonConvert.DeserializeObject<Config>(serialized);
+
+            Assert.True(config.GetBoolean("this.\"should[]\".work"));
+            Assert.True(deserialized.GetBoolean("this.\"should[]\".work"));
+            Assert.Equal(config, deserialized);
+        }
+
     }
 }

--- a/src/Hocon.Configuration/ConfigurationFactory.cs
+++ b/src/Hocon.Configuration/ConfigurationFactory.cs
@@ -110,7 +110,12 @@ namespace Hocon
             try
             {
                 var def = Load("hocon"); // new default
-                if (def == null || def.IsEmpty) return Load("akka"); // old Akka.NET-specific default
+                if (!def.IsNullOrEmpty())
+                    return def;
+
+                def = Load("akka"); // old Akka.NET-specific default
+                if (!def.IsNullOrEmpty())
+                    return def;
             }
             catch
             {

--- a/src/Hocon.Tests/PathTests.cs
+++ b/src/Hocon.Tests/PathTests.cs
@@ -108,5 +108,13 @@ akka {
             Assert.NotEqual(path1.Value, path2.Value);
             Assert.Equal("i am.\"kong.fu\".panda", path1.Value);
         }
+
+        [Fact]
+        public void QuotedKeyShouldHandleInvalidCharacters()
+        {
+            var hoconString = @"this.""should[]"".work = true";
+            var config = HoconParser.Parse(hoconString);
+            Assert.True(config.GetBoolean("this.\"should[]\".work"));
+        }
     }
 }

--- a/src/Hocon/Impl/HoconObject.cs
+++ b/src/Hocon/Impl/HoconObject.cs
@@ -174,7 +174,7 @@ namespace Hocon
             var i = new string(' ', indent * indentSize);
             var sb = new StringBuilder();
             foreach (var field in this)
-                sb.Append($"{i}{field.Key} : {field.Value.ToString(indent + 1, indentSize)},{Environment.NewLine}");
+                sb.Append($"{i}{(field.Key.NeedQuotes() ? field.Key.AddQuotes() : field.Key)} : {field.Value.ToString(indent + 1, indentSize)},{Environment.NewLine}");
             return sb.Length > 2 ? sb.ToString(0, sb.Length - Environment.NewLine.Length - 1) : sb.ToString();
         }
 


### PR DESCRIPTION
Keys with invalid characters such as period and angle braces are not serialized within quotation marks.