### PR TITLE
Make build scripts run in folders with spaces

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -102,8 +102,8 @@ Target "RunTests" (fun _ ->
     let runSingleProject project =
         let arguments =
             match (hasTeamCity) with
-            | true -> (sprintf "test -c Release --no-build --logger:trx --logger:\"console;verbosity=normal\" --results-directory %s -- -parallel none -teamcity" (outputTests))
-            | false -> (sprintf "test -c Release --no-build --logger:trx --logger:\"console;verbosity=normal\" --results-directory %s -- -parallel none" (outputTests))
+            | true -> (sprintf "test -c Release --no-build --logger:trx --logger:\"console;verbosity=normal\" --results-directory \"%s\" -- -parallel none -teamcity" (outputTests))
+            | false -> (sprintf "test -c Release --no-build --logger:trx --logger:\"console;verbosity=normal\" --results-directory \"%s\" -- -parallel none" (outputTests))
 
         let result = ExecProcess(fun info ->
             info.FileName <- "dotnet"
@@ -207,7 +207,7 @@ Target "CreateNuget" (fun _ ->
                     Configuration = configuration
                     AdditionalArgs = ["--include-symbols --no-build"]
                     VersionSuffix = overrideVersionSuffix project
-                    OutputPath = outputNuGet })
+                    OutputPath = "\"" + outputNuGet + "\"" })
 
     projects |> Seq.iter (runSingleProject)
 )

--- a/build.ps1
+++ b/build.ps1
@@ -156,6 +156,6 @@ $Arguments = @{
 
 # Start Fake
 Write-Host "Running build script..."
-Invoke-Expression "$FakeExePath `"build.fsx`" $ScriptArgs $Arguments"
+Invoke-Expression "& `"$FakeExePath`" `"build.fsx`" $ScriptArgs $Arguments"
 
 exit $LASTEXITCODE


### PR DESCRIPTION
Adapt build scripts s.t. it is possible to run the commands in directories where the absolute path contains spaces.

Basically the same I did for Akka a while back:
https://github.com/cptjazz/akka.net/commit/8c02bcf758e28cb1055811f527b5d54bd9aee76b
https://github.com/cptjazz/akka.net/commit/4f984bceffec20bc92beaf6f138f5a8f153c794b