### PR TITLE
HOCON v2.0.2 Release Notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,4 @@
-### 2.0.1 February 25 2020 ####
-Bugfixes and improvements made to HOCON 2.0.0
+### 2.0.2 February 27 2020 ####
+HOCON 2.0.2 contains a final stabilization of the HOCON 2.0 milestone, designed to provide 100% immutability to HOCON objects and high performance on reads.
 
-* [Bugfix: HoconValue.TryGetObject can throw System.ArgumentNullException](https://github.com/akkadotnet/HOCON/issues/233)
-* [Bugfix: System.InvalidOperationException : Collection was modified; enumeration operation may not execute](https://github.com/akkadotnet/HOCON/issues/234)
-* [Bugfix: unquoted key error during serialization](https://github.com/akkadotnet/HOCON/pull/223)
-* [Fixed NuGet symbol package publication](https://github.com/akkadotnet/HOCON/issues/222)
-
-For more details, please [see the issues in the HOCON v2.0.1 milestone here](https://github.com/akkadotnet/HOCON/milestone/7).
+See [the HOCON 2.0.2 milestone for a full set of changes](https://github.com/akkadotnet/HOCON/milestone/8).

--- a/src/common.props
+++ b/src/common.props
@@ -2,13 +2,9 @@
   <PropertyGroup>
     <Copyright>Copyright © 2014-2020 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>2.0.1</VersionPrefix>
-    <PackageReleaseNotes>Bugfixes and improvements made to HOCON 2.0.0
-[Bugfix: HoconValue.TryGetObject can throw System.ArgumentNullException](https://github.com/akkadotnet/HOCON/issues/233)
-[Bugfix: System.InvalidOperationException : Collection was modified; enumeration operation may not execute](https://github.com/akkadotnet/HOCON/issues/234)
-[Bugfix: unquoted key error during serialization](https://github.com/akkadotnet/HOCON/pull/223)
-[Fixed NuGet symbol package publication](https://github.com/akkadotnet/HOCON/issues/222)
-For more details, please [see the issues in the HOCON v2.0.1 milestone here](https://github.com/akkadotnet/HOCON/milestone/7).</PackageReleaseNotes>
+    <VersionPrefix>2.0.2</VersionPrefix>
+    <PackageReleaseNotes>HOCON 2.0.2 contains a final stabilization of the HOCON 2.0 milestone, designed to provide 100% immutability to HOCON objects and high performance on reads.
+See [the HOCON 2.0.2 milestone for a full set of changes](https://github.com/akkadotnet/HOCON/milestone/8).</PackageReleaseNotes>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/HOCON</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/HOCON/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
### 2.0.2 February 27 2020 ####
HOCON 2.0.2 contains a final stabilization of the HOCON 2.0 milestone, designed to provide 100% immutability to HOCON objects and high performance on reads.

See [the HOCON 2.0.2 milestone for a full set of changes](https://github.com/akkadotnet/HOCON/milestone/8).