### PR TITLE
Quoted string should be closed by the same token as the starting token.

### DIFF
--- a/src/HOCON.Tests/QuotedString.cs
+++ b/src/HOCON.Tests/QuotedString.cs
@@ -32,5 +32,21 @@ namespace Hocon.Tests
             unwrapped["gremlin"].Should().Be("Akka.Remote.Transport.FailureInjectorProvider,Akka.Remote");
             unwrapped["trttl"].Should().Be("Akka.Remote.Transport.ThrottlerProvider,Akka.Remote");
         }
+
+        [Fact]
+        public void Should_terminate_string_tokenize_with_the_same_quote_type()
+        {
+            var hocon = @"
+    quote1 = ""The 'string' should be tokenized as one string""
+    quote2 = 'The ""string"" should be tokenized as one string'
+    quote3 = """"""The '''string''' should be tokenized as one string""""""
+    quote4 = '''The """"""string"""""" should be tokenized as one string'''
+";
+            var parsed = HoconParser.Parse(hocon);
+            parsed.GetString("quote1").Should().Be("The 'string' should be tokenized as one string");
+            parsed.GetString("quote2").Should().Be("The \"string\" should be tokenized as one string");
+            parsed.GetString("quote3").Should().Be("The '''string''' should be tokenized as one string");
+            parsed.GetString("quote4").Should().Be("The \"\"\"string\"\"\" should be tokenized as one string");
+        }
     }
 }

--- a/src/Hocon/Impl/HoconTokenizer.cs
+++ b/src/Hocon/Impl/HoconTokenizer.cs
@@ -894,8 +894,8 @@ namespace Hocon
                 return false;
 
             var sb = new StringBuilder();
-            Take();
-            while (!EoF && !Matches('\"', '\''))
+            var startChar = TakeWithResult(1)[0];
+            while (!EoF && !Matches(startChar))
                 if (Matches("\\"))
                     sb.Append(PullEscapeSequence());
                 else
@@ -920,8 +920,8 @@ namespace Hocon
                 return false;
 
             var sb = new StringBuilder();
-            Take(3);
-            while (!EoF && !Matches("\"\"\"", "'''"))
+            var startString = TakeWithResult(3);
+            while (!EoF && !Matches(startString))
                 if (Matches("\\"))
                     sb.Append(PullEscapeSequence());
                 else


### PR DESCRIPTION
Parser tokenizer can be closed by either double quote or single quote, it should only be closed by the same quote type it started with.