### PR TITLE
Use include callback in configuration source

### DIFF
--- a/src/Hocon.Extensions.Configuration.Tests/IncludeTest.cs
+++ b/src/Hocon.Extensions.Configuration.Tests/IncludeTest.cs
@@ -1,0 +1,33 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Hocon.Extensions.Configuration.Tests
+{
+    public class IncludeTest
+    {
+        [Fact]
+        public void ProcessIncludes()
+        {
+            var hocon = @"{
+                servers { include file(""servers.hocon"") }
+            }";
+
+            var hoconConfigSource = new HoconConfigurationSource
+            {
+                FileProvider = TestStreamHelpers.StringToFileProvider(hocon),
+                IncludeCallback = (type, value) => Task.FromResult(@"{
+    server1 = 10.0.0.1
+    server2 = 10.0.0.2
+}")
+            };
+
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.Add(hoconConfigSource);
+            var config = configurationBuilder.Build();
+
+            Assert.Equal("10.0.0.1", config["servers:server1"]);
+            Assert.Equal("10.0.0.2", config["servers:server2"]);
+        }
+    }
+}

--- a/src/Hocon.Extensions.Configuration/HoconConfigurationExtensions.cs
+++ b/src/Hocon.Extensions.Configuration/HoconConfigurationExtensions.cs
@@ -72,9 +72,10 @@ namespace Hocon.Extensions.Configuration
         /// </param>
         /// <param name="optional">Whether the file is optional.</param>
         /// <param name="reloadOnChange">Whether the configuration should be reloaded if the file changes.</param>
+        /// <param name="includeCallback">Include callback.</param>
         /// <returns>The <see cref="IConfigurationBuilder" />.</returns>
         public static IConfigurationBuilder AddHoconFile(this IConfigurationBuilder builder, IFileProvider provider,
-            string path, bool optional, bool reloadOnChange)
+            string path, bool optional, bool reloadOnChange, HoconIncludeCallbackAsync includeCallback = null)
         {
             if (builder == null) throw new ArgumentNullException(nameof(builder));
             if (string.IsNullOrEmpty(path)) throw new ArgumentException(Resources.Error_InvalidFilePath, nameof(path));
@@ -85,6 +86,7 @@ namespace Hocon.Extensions.Configuration
                 s.Path = path;
                 s.Optional = optional;
                 s.ReloadOnChange = reloadOnChange;
+                s.IncludeCallback = includeCallback;
                 s.ResolveFileProvider();
             });
         }

--- a/src/Hocon.Extensions.Configuration/HoconConfigurationFileParser.cs
+++ b/src/Hocon.Extensions.Configuration/HoconConfigurationFileParser.cs
@@ -19,7 +19,15 @@ namespace Hocon.Extensions.Configuration
         private readonly IDictionary<string, string> _data =
             new SortedDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
+        private readonly HoconIncludeCallbackAsync _includeCallback;
+        
         private string _currentPath;
+
+
+        public HoconConfigurationFileParser(HoconIncludeCallbackAsync includeCallback)
+        {
+            _includeCallback = includeCallback;
+        }
 
         public IDictionary<string, string> Parse(Stream input)
         {
@@ -28,7 +36,7 @@ namespace Hocon.Extensions.Configuration
             using (var textStream = new StreamReader(input))
             {
                 var content = textStream.ReadToEnd();
-                var hoconConfig = HoconParser.Parse(content);
+                var hoconConfig = HoconParser.Parse(content, _includeCallback ?? HoconConfigurationSource.DefaultIncludeCallback);
                 VisitHoconObject(hoconConfig.Value.GetObject());
             }
 

--- a/src/Hocon.Extensions.Configuration/HoconConfigurationProvider.cs
+++ b/src/Hocon.Extensions.Configuration/HoconConfigurationProvider.cs
@@ -17,12 +17,15 @@ namespace Hocon.Extensions.Configuration
     /// </summary>
     public class HoconConfigurationProvider : FileConfigurationProvider
     {
+        private readonly HoconConfigurationSource _source;
+
         /// <summary>
         ///     Initializes a new instance with the specified source.
         /// </summary>
         /// <param name="source">The source settings.</param>
         public HoconConfigurationProvider(HoconConfigurationSource source) : base(source)
         {
+            _source = source ?? throw new ArgumentNullException(nameof(source));
         }
 
         /// <summary>
@@ -31,7 +34,7 @@ namespace Hocon.Extensions.Configuration
         /// <param name="stream">The stream to read.</param>
         public override void Load(Stream stream)
         {
-            var parser = new HoconConfigurationFileParser();
+            var parser = new HoconConfigurationFileParser(_source.IncludeCallback);
             try
             {
                 Data = parser.Parse(stream);

--- a/src/Hocon.Extensions.Configuration/HoconConfigurationSource.cs
+++ b/src/Hocon.Extensions.Configuration/HoconConfigurationSource.cs
@@ -14,6 +14,16 @@ namespace Hocon.Extensions.Configuration
     public class HoconConfigurationSource : FileConfigurationSource
     {
         /// <summary>
+        ///     Default include callback.
+        /// </summary>
+        public static HoconIncludeCallbackAsync DefaultIncludeCallback { get; set; } = null;
+
+        /// <summary>
+        ///     Include callback for this source.
+        /// </summary>
+        public HoconIncludeCallbackAsync IncludeCallback { get; set; } = null;
+
+        /// <summary>
         ///     Builds the <see cref="HoconConfigurationProvider" /> for this source.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder" />.</param>


### PR DESCRIPTION
This change allows to use `include` directives in Hocon files which are used by configuration extension methods.