### PR TITLE
Have includes occur in the correct order

### DIFF
--- a/src/Hocon/HoconParser.cs
+++ b/src/Hocon/HoconParser.cs
@@ -469,6 +469,7 @@ namespace Hocon
                                 $"found `{_tokens.Current.Type}` instead.");
 
                         owner.ReParent(ParseInclude());
+                        hoconObject = owner.GetObject();
                         valueWasParsed = true;
                         break;
 


### PR DESCRIPTION
## Changes

Includes are currently handled incorrectly. Whether they occur first or last in the file they are given precedence, as if they occurred last. So if you do

```hocon
include "other.conf"

foo {
  a: 1
  c: 4
}
```

where `other.conf` is

```hocon
foo {
  a: 2
  b: 3
}
```

the result is

```hocon
foo {
  a: 2
  b: 3
  c: 4
}
```

with the value of `a` coming from the included file whereas, because the include occurs first in the file, the correct result should be `a: 1`.

This change fixes the problem though admittedly I don't understand the code well enough to know if it's the most appropriate solution. I also haven't added a test case since I could find no existing `include` tests. If you're interested in merging this I'm happy to add a test.