### PR TITLE
Have includes occur in the correct order

### DIFF
--- a/src/Hocon.Configuration/Hocon.Configuration.csproj
+++ b/src/Hocon.Configuration/Hocon.Configuration.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>Hocon</RootNamespace>
     <PackageTags>$(HoconPackageTags)</PackageTags>
     <Description>HOCON (Human-Optimized Config Object Notation) parser and application-ready implementation.</Description>
+    <NoWarn>$(NoWarn);NU1506</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,7 +15,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkVersion)' ">
     <Reference Include="System.Configuration" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework)' == '$(NetStandardLibVersion)'">
     <PackageReference Include="System.Configuration.ConfigurationManager" />
   </ItemGroup>

--- a/src/Hocon.Configuration/HoconConfigurationFactory.cs
+++ b/src/Hocon.Configuration/HoconConfigurationFactory.cs
@@ -45,6 +45,19 @@ namespace Hocon
         ///     Generates a configuration defined in the supplied
         ///     HOCON (Human-Optimized Config Object Notation) string.
         /// </summary>
+        /// <param name="document">A document that contains configuration options to use.</param>
+        /// <param name="includeCallback">callback used to resolve includes</param>
+        /// <returns>The configuration defined in the supplied HOCON string.</returns>
+        public static Config ParseDocument(HoconDocument document, HoconIncludeDocumentCallbackAsync includeCallback)
+        {
+            HoconRoot res = HoconParser.Parse(document, includeCallback);
+            return new Config(res);
+        }
+
+        /// <summary>
+        ///     Generates a configuration defined in the supplied
+        ///     HOCON (Human-Optimized Config Object Notation) string.
+        /// </summary>
         /// <param name="hocon">A string that contains configuration options to use.</param>
         /// <returns>The configuration defined in the supplied HOCON string.</returns>
         public static Config ParseString(string hocon)
@@ -99,7 +112,7 @@ namespace Hocon
                 foreach(var extension in DefaultHoconFileExtensions)
                 {
                     var path = $"{filePath}.{extension}";
-                    if (File.Exists(path)) 
+                    if (File.Exists(path))
                         return ParseString(File.ReadAllText(path));
                 }
             } else

--- a/src/Hocon.Configuration/HoconConfigurationFactory.cs
+++ b/src/Hocon.Configuration/HoconConfigurationFactory.cs
@@ -48,9 +48,9 @@ namespace Hocon
         /// <param name="document">A document that contains configuration options to use.</param>
         /// <param name="includeCallback">callback used to resolve includes</param>
         /// <returns>The configuration defined in the supplied HOCON string.</returns>
-        public static Config ParseDocument(HoconDocument document, HoconIncludeDocumentCallbackAsync includeCallback)
+        public static Config ParseDocument(HoconDocument document, HoconIncludeDocumentCallbackAsync includeCallback, HoconEnvironmentGetCallback envGetCallback = null)
         {
-            HoconRoot res = HoconParser.Parse(document, includeCallback);
+            HoconRoot res = HoconParser.Parse(document, includeCallback, envGetCallback);
             return new Config(res);
         }
 

--- a/src/Hocon/Hocon.csproj
+++ b/src/Hocon/Hocon.csproj
@@ -3,5 +3,6 @@
     <TargetFrameworks>$(NetFrameworkVersion);$(NetStandardLibVersion)</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>HOCON (Human-Optimized Config Object Notation) core API implementation. For full access inside your application, install the Hocon.Configuration package.</Description>
+    <NoWarn>$(NoWarn);NU1506</NoWarn>
   </PropertyGroup>
 </Project>

--- a/src/Hocon/HoconParser.cs
+++ b/src/Hocon/HoconParser.cs
@@ -12,7 +12,62 @@ using Hocon.Extensions;
 
 namespace Hocon
 {
+
+    /// <summary>
+    /// The source of a hocon document along with optionally a source that
+    /// indicates where the document came from.
+    /// </summary>
+    public class HoconDocument
+    {
+        private readonly string text;
+        private readonly HoconDocumentSource source;
+
+        public HoconDocument(string text, HoconDocumentSource source)
+        {
+            this.text = text;
+            this.source = source;
+        }
+
+        public string Text => text;
+
+        public HoconDocumentSource Source => source;
+
+        public static HoconDocument FromFile(string path, string contents) =>
+            new(
+                text: contents,
+                source: new HoconDocumentSource(HoconCallbackType.File, path)
+            );
+
+        public static HoconDocument FromString(string contents) =>
+            new(text: contents, source: null);
+
+    }
+
+    /// <summary>
+    /// A description of where a hocon document came from or, in the case of
+    /// includes, where to load it from.
+    /// </summary>
+    public class HoconDocumentSource
+    {
+        private readonly HoconCallbackType type;
+        private readonly string what;
+
+        public HoconDocumentSource(HoconCallbackType type, string what)
+        {
+            this.type = type;
+            this.what = what;
+        }
+
+        public HoconCallbackType Type => type;
+
+        public string What => what;
+    }
+
     public delegate Task<string> HoconIncludeCallbackAsync(HoconCallbackType callbackType, string value);
+
+    public delegate Task<string> HoconIncludeDocumentCallbackAsync(
+        HoconDocumentSource include,
+        HoconDocument document);
 
     /// <summary>
     ///     This class contains methods used to parse HOCON (Human-Optimized Config Object Notation)
@@ -21,12 +76,28 @@ namespace Hocon
     public sealed class HoconParser
     {
         private readonly List<HoconSubstitution> _substitutions = new List<HoconSubstitution>();
-        private HoconIncludeCallbackAsync _includeCallback = (type, value) => Task.FromResult("{}");
+        private HoconIncludeDocumentCallbackAsync _includeCallback = (i, p) => Task.FromResult("{}");
+        private HoconDocument _document = default;
         private HoconValue _root;
 
         private HoconTokenizerResult _tokens;
 
         private HoconPath Path { get; } = new HoconPath();
+
+        /// <summary>
+        ///     Parses the supplied HOCON configuration string into a root element.
+        /// </summary>
+        /// <param name="doc">The document that contains a HOCON configuration string.</param>
+        /// <param name="includeCallback">Callback used to resolve includes</param>
+        /// <returns>The root element created from the supplied HOCON configuration string.</returns>
+        /// <exception cref="HoconParserException">
+        ///     This exception is thrown when an unresolved substitution is encountered.
+        ///     It also occurs when any error is encountered while tokenizing or parsing the configuration string.
+        /// </exception>
+        public static HoconRoot Parse(HoconDocument doc, HoconIncludeDocumentCallbackAsync includeCallback = null)
+        {
+            return new HoconParser().ParseText(doc, true, includeCallback).Normalize();
+        }
 
         /// <summary>
         ///     Parses the supplied HOCON configuration string into a root element.
@@ -39,12 +110,14 @@ namespace Hocon
         ///     It also occurs when any error is encountered while tokenizing or parsing the configuration string.
         /// </exception>
         public static HoconRoot Parse(string text, HoconIncludeCallbackAsync includeCallback = null)
-        {
-            return new HoconParser().ParseText(text, true, includeCallback).Normalize();
-        }
+            => Parse(new HoconDocument(text, null), OldToNewCallback(includeCallback));
 
-        private HoconRoot ParseText(string text, bool resolveSubstitutions, HoconIncludeCallbackAsync includeCallback)
+        private static HoconIncludeDocumentCallbackAsync OldToNewCallback(HoconIncludeCallbackAsync old) =>
+            (old is null) ? null : (inc, _) => old.Invoke(inc.Type, inc.What);
+
+        private HoconRoot ParseText(HoconDocument doc, bool resolveSubstitutions, HoconIncludeDocumentCallbackAsync includeCallback)
         {
+            string text = doc.Text;
             if (string.IsNullOrWhiteSpace(text))
                 throw new HoconParserException(
                     $"Parameter {nameof(text)} is null or empty.\n" +
@@ -52,6 +125,7 @@ namespace Hocon
 
             if (includeCallback != null)
                 _includeCallback = includeCallback;
+            _document = doc;
 
             try
             {
@@ -409,7 +483,9 @@ namespace Hocon
             // Consume the last token
             _tokens.ToNextSignificant();
 
-            var includeHocon = _includeCallback(callbackType, fileName).ConfigureAwait(false).GetAwaiter().GetResult();
+            var include = new HoconDocumentSource(callbackType, fileName);
+
+            var includeHocon = _includeCallback(include, _document).ConfigureAwait(false).GetAwaiter().GetResult();
 
             if (string.IsNullOrWhiteSpace(includeHocon))
             {
@@ -419,7 +495,8 @@ namespace Hocon
                 return new HoconEmptyValue(null);
             }
 
-            var includeRoot = new HoconParser().ParseText(includeHocon, false, _includeCallback);
+            var includeDoc = new HoconDocument(includeHocon, include);
+            var includeRoot = new HoconParser().ParseText(includeDoc, false, _includeCallback);
             /*
             if (owner != null && owner.Type != HoconType.Empty && owner.Type != includeRoot.Value.Type)
                 throw HoconParserException.Create(includeToken, Path,

--- a/src/Hocon/HoconParser.cs
+++ b/src/Hocon/HoconParser.cs
@@ -69,6 +69,8 @@ namespace Hocon
         HoconDocumentSource include,
         HoconDocument document);
 
+    public delegate string HoconEnvironmentGetCallback(string key, string defaultValue);
+
     /// <summary>
     ///     This class contains methods used to parse HOCON (Human-Optimized Config Object Notation)
     ///     configuration strings.
@@ -77,6 +79,7 @@ namespace Hocon
     {
         private readonly List<HoconSubstitution> _substitutions = new List<HoconSubstitution>();
         private HoconIncludeDocumentCallbackAsync _includeCallback = (i, p) => Task.FromResult("{}");
+        private HoconEnvironmentGetCallback _envGetCallback = (k, d) => Environment.GetEnvironmentVariable(k);
         private HoconDocument _document = default;
         private HoconValue _root;
 
@@ -94,9 +97,9 @@ namespace Hocon
         ///     This exception is thrown when an unresolved substitution is encountered.
         ///     It also occurs when any error is encountered while tokenizing or parsing the configuration string.
         /// </exception>
-        public static HoconRoot Parse(HoconDocument doc, HoconIncludeDocumentCallbackAsync includeCallback = null)
+        public static HoconRoot Parse(HoconDocument doc, HoconIncludeDocumentCallbackAsync includeCallback = null, HoconEnvironmentGetCallback envGetCallback = null)
         {
-            return new HoconParser().ParseText(doc, true, includeCallback).Normalize();
+            return new HoconParser().ParseText(doc, true, includeCallback, envGetCallback).Normalize();
         }
 
         /// <summary>
@@ -115,7 +118,11 @@ namespace Hocon
         private static HoconIncludeDocumentCallbackAsync OldToNewCallback(HoconIncludeCallbackAsync old) =>
             (old is null) ? null : (inc, _) => old.Invoke(inc.Type, inc.What);
 
-        private HoconRoot ParseText(HoconDocument doc, bool resolveSubstitutions, HoconIncludeDocumentCallbackAsync includeCallback)
+        private HoconRoot ParseText(
+            HoconDocument doc,
+            bool resolveSubstitutions,
+            HoconIncludeDocumentCallbackAsync includeCallback,
+            HoconEnvironmentGetCallback envGetCallback)
         {
             string text = doc.Text;
             if (string.IsNullOrWhiteSpace(text))
@@ -125,6 +132,8 @@ namespace Hocon
 
             if (includeCallback != null)
                 _includeCallback = includeCallback;
+            if (envGetCallback != null)
+                _envGetCallback = envGetCallback;
             _document = doc;
 
             try
@@ -179,7 +188,7 @@ namespace Hocon
                 string envValue = null;
                 try
                 {
-                    envValue = Environment.GetEnvironmentVariable(sub.Path.Value);
+                    envValue = _envGetCallback(sub.Path.Value, sub.DefaultValue);
                 }
                 catch (Exception)
                 {
@@ -259,7 +268,7 @@ namespace Hocon
         private bool IsValueCyclic(HoconField field, HoconSubstitution sub)
         {
             var pendingValues = new Stack<HoconValue>();
-            var visitedFields = new List<HoconField> {field};
+            var visitedFields = new List<HoconField> { field };
             var pendingSubs = new Stack<HoconSubstitution>();
             pendingSubs.Push(sub);
 
@@ -496,7 +505,7 @@ namespace Hocon
             }
 
             var includeDoc = new HoconDocument(includeHocon, include);
-            var includeRoot = new HoconParser().ParseText(includeDoc, false, _includeCallback);
+            var includeRoot = new HoconParser().ParseText(includeDoc, false, _includeCallback, _envGetCallback);
             /*
             if (owner != null && owner.Type != HoconType.Empty && owner.Type != includeRoot.Value.Type)
                 throw HoconParserException.Create(includeToken, Path,
@@ -768,9 +777,22 @@ namespace Hocon
                         if (value == null)
                             value = new HoconValue(owner);
 
-                        var pointerPath = HoconPath.Parse(_tokens.Current.Value);
+                        HoconPath pointerPath;
+                        string defaultValue;
+                        string refStr = _tokens.Current.Value;
+                        var colonIndex = refStr.IndexOf(":-");
+                        if (colonIndex == -1)
+                        {
+                            pointerPath = HoconPath.Parse(refStr);
+                            defaultValue = null;
+                        }
+                        else
+                        {
+                            pointerPath = HoconPath.Parse(refStr.Substring(0, colonIndex));
+                            defaultValue = refStr.Substring(colonIndex + 2);
+                        }
                         var sub = new HoconSubstitution(value, pointerPath, _tokens.Current,
-                            _tokens.Current.Type == TokenType.SubstituteRequired);
+                            _tokens.Current.Type == TokenType.SubstituteRequired, defaultValue);
                         _substitutions.Add(sub);
                         _tokens.Next();
                         value.Add(sub);
@@ -780,7 +802,7 @@ namespace Hocon
                         if (value == null)
                             value = new HoconValue(owner);
 
-                        var subAssign = new HoconSubstitution(value, new HoconPath(Path), _tokens.Current, false);
+                        var subAssign = new HoconSubstitution(value, new HoconPath(Path), _tokens.Current, false, null);
                         _substitutions.Add(subAssign);
                         value.Add(subAssign);
                         value.Add(ParsePlusEqualAssignArray(value));
@@ -851,7 +873,7 @@ namespace Hocon
                             "Invalid Hocon include. Hocon config substitution type must be the same as the field it's merged into. " +
                             $"Expected type: `{currentArray.Type}`, type returned by include callback: `{includeValue.Type}`");
 
-                    currentArray.Add((HoconValue) includeValue.Clone(currentArray));
+                    currentArray.Add((HoconValue)includeValue.Clone(currentArray));
                     break;
 
                 case TokenType.StartOfArray:

--- a/src/Hocon/HoconParser.cs
+++ b/src/Hocon/HoconParser.cs
@@ -469,6 +469,7 @@ namespace Hocon
                                 $"found `{_tokens.Current.Type}` instead.");
 
                         owner.ReParent(ParseInclude());
+                        hoconObject = owner.GetObject();
                         valueWasParsed = true;
                         break;
 

--- a/src/Hocon/Impl/HoconSubstitution.cs
+++ b/src/Hocon/Impl/HoconSubstitution.cs
@@ -35,7 +35,7 @@ namespace Hocon
         /// <param name="required">Marks wether this substitution uses the ${? notation or not.</param>
         /// ///
         /// <param name="lineInfo">The <see cref="IHoconLineInfo" /> of this substitution, used for exception generation purposes.</param>
-        internal HoconSubstitution(IHoconElement parent, HoconPath path, IHoconLineInfo lineInfo, bool required)
+        internal HoconSubstitution(IHoconElement parent, HoconPath path, IHoconLineInfo lineInfo, bool required, string defaultValue)
         {
             if (parent == null)
                 throw new ArgumentNullException(nameof(parent), "HoconSubstitution parent can not be null.");
@@ -48,7 +48,8 @@ namespace Hocon
             LineNumber = lineInfo.LineNumber;
             Required = required;
             Path = path;
-            
+            DefaultValue = defaultValue;
+
             _parentsToResolveFor.Add(Parent as HoconValue);
         }
 
@@ -71,6 +72,8 @@ namespace Hocon
         ///     The full path to the value which should substitute this instance.
         /// </summary>
         public HoconPath Path { get; }
+
+        public string DefaultValue { get; }
 
         /// <summary>
         ///     The evaluated value from the Path property


### PR DESCRIPTION
## Changes

Includes are currently handled incorrectly. Whether they occur first or last in the file they are given precedence, as if they occurred last. So if you do

```hocon
include "other.conf"

foo {
  a: 1
  c: 4
}
```

where `other.conf` is

```hocon
foo {
  a: 2
  b: 3
}
```

the result is

```hocon
foo {
  a: 2
  b: 3
  c: 4
}
```

with the value of `a` coming from the included file whereas, because the include occurs first in the file, the correct result should be `a: 1`.

This change fixes the problem though admittedly I don't understand the code well enough to know if it's the most appropriate solution. I also haven't added a test case since I could find no existing `include` tests. If you're interested in merging this I'm happy to add a test.